### PR TITLE
fix workpool version breakage

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,8 +13,8 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       - run: npm i
       - run: npm run build
+      - run: npx pkg-pr-new publish
       - run: cd example && npm i && cd ..
       - run: npm run typecheck
       - run: cd example && npm run lint && cd ..
       - run: npm test
-      - run: npx pkg-pr-new publish

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,31 +1,55 @@
 import {
   createFunctionHandle,
-  FunctionArgs,
-  FunctionReference,
-  FunctionReturnType,
-  FunctionVisibility,
-  GenericDataModel,
-  GenericMutationCtx,
-  GenericQueryCtx,
-  RegisteredMutation,
-  ReturnValueForOptionalValidator,
+  type FunctionArgs,
+  type FunctionReference,
+  type FunctionReturnType,
+  type FunctionVisibility,
+  type GenericDataModel,
+  type GenericMutationCtx,
+  type GenericQueryCtx,
+  type RegisteredMutation,
+  type ReturnValueForOptionalValidator,
 } from "convex/server";
 import { safeFunctionName } from "./safeFunctionName.js";
-import { ObjectType, PropertyValidators, Validator } from "convex/values";
+import type { ObjectType, PropertyValidators, Validator } from "convex/values";
 import { api } from "../component/_generated/api.js";
 import { OnCompleteArgs, OpaqueIds, UseApi, WorkflowId } from "../types.js";
 import { workflowMutation } from "./workflowMutation.js";
-import {
-  NameOption,
+import type {
   RetryOption,
-  SchedulerOptions,
   WorkpoolOptions,
   WorkpoolRetryOptions,
 } from "@convex-dev/workpool";
-import { Step } from "../component/schema.js";
+import type { Step } from "../component/schema.js";
 export { vWorkflowId } from "../types.js";
 
 export type { WorkflowId };
+
+export type RunOptions = {
+  /**
+   * The name of the function. By default, if you pass in api.foo.bar.baz,
+   * it will use "foo/bar:baz" as the name. If you pass in a function handle,
+   * it will use the function handle directly.
+   */
+  name?: string;
+} & (
+  | {
+      /**
+       * The time (ms since epoch) to run the action at.
+       * If not provided, the action will be run as soon as possible.
+       * Note: this is advisory only. It may run later.
+       */
+      runAt?: number;
+    }
+  | {
+      /**
+       * The number of milliseconds to run the action after.
+       * If not provided, the action will be run as soon as possible.
+       * Note: this is advisory only. It may run later.
+       */
+      runAfter?: number;
+    }
+);
 
 export type CallbackOptions = {
   /**
@@ -73,7 +97,7 @@ export type WorkflowStep = {
   runQuery<Query extends FunctionReference<"query", "internal">>(
     query: Query,
     args: FunctionArgs<Query>,
-    opts?: NameOption & SchedulerOptions,
+    opts?: RunOptions,
   ): Promise<FunctionReturnType<Query>>;
 
   /**
@@ -86,7 +110,7 @@ export type WorkflowStep = {
   runMutation<Mutation extends FunctionReference<"mutation", "internal">>(
     mutation: Mutation,
     args: FunctionArgs<Mutation>,
-    opts?: NameOption & SchedulerOptions,
+    opts?: RunOptions,
   ): Promise<FunctionReturnType<Mutation>>;
 
   /**
@@ -99,7 +123,7 @@ export type WorkflowStep = {
   runAction<Action extends FunctionReference<"action", "internal">>(
     action: Action,
     args: FunctionArgs<Action>,
-    opts?: NameOption & SchedulerOptions & RetryOption,
+    opts?: RunOptions & RetryOption,
   ): Promise<FunctionReturnType<Action>>;
 };
 

--- a/src/client/step.ts
+++ b/src/client/step.ts
@@ -1,25 +1,25 @@
 import { BaseChannel } from "async-channel";
 import {
-  GenericMutationCtx,
-  GenericDataModel,
-  FunctionType,
-  FunctionReference,
+  type GenericMutationCtx,
+  type GenericDataModel,
+  type FunctionType,
+  type FunctionReference,
   createFunctionHandle,
 } from "convex/server";
 import { convexToJson, Value } from "convex/values";
 import {
-  JournalEntry,
+  type JournalEntry,
   journalEntrySize,
   valueSize,
 } from "../component/schema.js";
 import { api } from "../component/_generated/api.js";
-import { UseApi } from "../types.js";
-import {
+import type { UseApi } from "../types.js";
+import type {
   RetryBehavior,
   WorkpoolOptions,
   RunResult,
-  SchedulerOptions,
 } from "@convex-dev/workpool";
+import type { SchedulerOptions } from "./types.js";
 
 export type OriginalEnv = {
   Date: {

--- a/src/client/stepContext.ts
+++ b/src/client/stepContext.ts
@@ -6,13 +6,9 @@ import {
   FunctionType,
 } from "convex/server";
 import { safeFunctionName } from "./safeFunctionName.js";
-import { WorkflowStep } from "./index.js";
-import { StepRequest } from "./step.js";
-import {
-  NameOption,
-  RetryOption,
-  SchedulerOptions,
-} from "@convex-dev/workpool";
+import type { RunOptions, WorkflowStep } from "./index.js";
+import type { StepRequest } from "./step.js";
+import type { RetryOption } from "@convex-dev/workpool";
 
 export class StepContext implements WorkflowStep {
   constructor(
@@ -23,7 +19,7 @@ export class StepContext implements WorkflowStep {
   async runQuery<Query extends FunctionReference<"query", "internal">>(
     query: Query,
     args: FunctionArgs<Query>,
-    opts?: NameOption & SchedulerOptions,
+    opts?: RunOptions,
   ): Promise<FunctionReturnType<Query>> {
     return this.runFunction("query", query, args, opts);
   }
@@ -31,7 +27,7 @@ export class StepContext implements WorkflowStep {
   async runMutation<Mutation extends FunctionReference<"mutation", "internal">>(
     mutation: Mutation,
     args: FunctionArgs<Mutation>,
-    opts?: NameOption & SchedulerOptions,
+    opts?: RunOptions,
   ): Promise<FunctionReturnType<Mutation>> {
     return this.runFunction("mutation", mutation, args, opts);
   }
@@ -39,7 +35,7 @@ export class StepContext implements WorkflowStep {
   async runAction<Action extends FunctionReference<"action", "internal">>(
     action: Action,
     args: FunctionArgs<Action>,
-    opts?: NameOption & SchedulerOptions & RetryOption,
+    opts?: RunOptions & RetryOption,
   ): Promise<FunctionReturnType<Action>> {
     return this.runFunction("action", action, args, opts);
   }
@@ -50,7 +46,7 @@ export class StepContext implements WorkflowStep {
     functionType: FunctionType,
     f: F,
     args: unknown,
-    opts?: NameOption & SchedulerOptions & RetryOption,
+    opts?: RunOptions & RetryOption,
   ): Promise<unknown> {
     let send: unknown;
     const { name, ...rest } = opts ?? {};

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,0 +1,26 @@
+export type RunOptions = {
+  /**
+   * The name of the function. By default, if you pass in api.foo.bar.baz,
+   * it will use "foo/bar:baz" as the name. If you pass in a function handle,
+   * it will use the function handle directly.
+   */
+  name?: string;
+} & SchedulerOptions;
+
+export type SchedulerOptions =
+  | {
+      /**
+       * The time (ms since epoch) to run the action at.
+       * If not provided, the action will be run as soon as possible.
+       * Note: this is advisory only. It may run later.
+       */
+      runAt?: number;
+    }
+  | {
+      /**
+       * The number of milliseconds to run the action after.
+       * If not provided, the action will be run as soon as possible.
+       * Note: this is advisory only. It may run later.
+       */
+      runAfter?: number;
+    };

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -2,7 +2,6 @@ import {
   vResultValidator,
   RunResult,
   vWorkIdValidator,
-  vOnComplete,
 } from "@convex-dev/workpool";
 import { defineSchema, defineTable } from "convex/server";
 import { convexToJson, Infer, v, Value } from "convex/values";
@@ -31,6 +30,12 @@ export function resultSize(result: RunResult): number {
   }
   return size;
 }
+
+export const vOnComplete = v.object({
+  fnHandle: v.string(), // mutation
+  context: v.optional(v.any()),
+});
+export type OnComplete = Infer<typeof vOnComplete>;
 
 const workflowObject = {
   name: v.optional(v.string()),

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -1,4 +1,4 @@
-import { vOnComplete, vResultValidator } from "@convex-dev/workpool";
+import { vResultValidator } from "@convex-dev/workpool";
 import { assert } from "convex-helpers";
 import { FunctionHandle } from "convex/server";
 import { Infer, v } from "convex/values";
@@ -6,7 +6,7 @@ import { mutation, MutationCtx, query } from "./_generated/server.js";
 import { Logger, logLevel } from "./logging.js";
 import { getWorkflow } from "./model.js";
 import { getWorkpool } from "./pool.js";
-import { journalDocument, workflowDocument } from "./schema.js";
+import { journalDocument, vOnComplete, workflowDocument } from "./schema.js";
 import { getDefaultLogger } from "./utils.js";
 import { WorkflowId, OnCompleteArgs } from "../types.js";
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Workpool changed the meaning of `vOnComplete` and we were re-using it 😬

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
