### PR TITLE
Enhance WorkflowStatus type to include returnValue for completed status

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -145,7 +145,7 @@ export type WorkflowDefinition<
 
 export type WorkflowStatus =
   | { type: "inProgress"; running: OpaqueIds<Step>[] }
-  | { type: "completed" }
+  | { type: "completed"; returnValue: unknown }
   | { type: "canceled" }
   | { type: "failed"; error: string };
 
@@ -249,7 +249,7 @@ export class WorkflowManager {
       case "failed":
         return { type: "failed", error: workflow.runResult.error };
       case "success":
-        return { type: "completed" };
+        return { type: "completed", returnValue: workflow.runResult.returnValue };
     }
   }
 


### PR DESCRIPTION
There is currently no way to get the return value of a workflow except for getting it in an `onComplete` handler. This PR adds the `returnValue` to the WorkflowStatus when the status is "completed".


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.