### PR TITLE
Re-export type `WorkflowStep`

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -20,8 +20,8 @@ import { safeFunctionName } from "./safeFunctionName.js";
 import type { OpaqueIds, WorkflowComponent, WorkflowStep } from "./types.js";
 import { workflowMutation } from "./workflowMutation.js";
 
-export { vWorkflowId, type WorkflowId, type WorkflowStep } from "../types.js";
-export type { RunOptions } from "./types.js";
+export { vWorkflowId, type WorkflowId } from "../types.js";
+export type { RunOptions, WorkflowStep } from "./types.js";
 
 export type CallbackOptions = {
   /**


### PR DESCRIPTION
<!-- Describe your PR here. -->
Re-export the `WorkflowStep` type for use in helpers like

```typescript
async function someWorkflowLogic(step: WorkflowStep, input: string) {
  const output = await step.runMutation(...)
}
```


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
