### PR TITLE
make step types match ctx better

### DIFF
--- a/src/client/step.ts
+++ b/src/client/step.ts
@@ -8,6 +8,7 @@ import {
   createFunctionHandle,
   type FunctionReference,
   type FunctionType,
+  type FunctionVisibility,
   type GenericDataModel,
   type GenericMutationCtx,
 } from "convex/server";
@@ -31,7 +32,7 @@ export type StepRequest = {
     | {
         kind: "function";
         functionType: FunctionType;
-        function: FunctionReference<FunctionType, "internal">;
+        function: FunctionReference<FunctionType, FunctionVisibility>;
         args: unknown;
       }
     | {


### PR DESCRIPTION
<!-- Describe your PR here. -->

Currently the WorkflowCtx doesn't match `Pick<MutationCtx, "runMutation">` or similar. This explores what it'd take to make that easier. 

Currently components that want to work with Workflow have to define their `runMutation` like so:

```ts
export type RunMutationCtx = RunQueryCtx & {
  runMutation: <Mutation extends FunctionReference<"mutation", "internal">>(
    mutation: Mutation,
    args: FunctionArgs<Mutation>,
  ) => Promise<FunctionReturnType<Mutation>>;
};
```
- only "internal" functions as args
- `args` is a required argument, not allowed to omit it

FYI @thomasballinger this captures the delta between our ctx and workflow right now. scoping to "internal" is maybe overkill - was just trying to avoid people accidentally exposing their steps

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
