### PR TITLE
use ValidatedEvent type instead of defineEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,14 +467,14 @@ await workflow.sendEvent(ctx, { name, workflowId, error: "An error occurred" });
 
 #### Sharing event definitions
 
-Use `defineEvent` to define an event's name and validator in one place, then
+Use a shared object to define an event's name and validator in one place, then
 share it between the workflow and the sender:
 
 ```ts
-const approvalEvent = defineEvent({
-  name: "approval",
+const approvalEvent = {
+  name: "approval" as const,
   validator: v.object({ approved: v.boolean() }),
-});
+} satisfies ValidatedEvent;
 
 // In the workflow:
 const approval = await ctx.awaitEvent(approvalEvent);

--- a/example/convex/userConfirmation.ts
+++ b/example/convex/userConfirmation.ts
@@ -1,5 +1,5 @@
 import {
-  defineEvent,
+  ValidatedEvent,
   vWorkflowId,
   WorkflowManager,
 } from "@convex-dev/workflow";
@@ -7,13 +7,13 @@ import { v } from "convex/values";
 import { components, internal } from "./_generated/api";
 import { internalAction, internalMutation } from "./_generated/server";
 
-export const approvalEvent = defineEvent({
-  name: "approval",
+export const approvalEvent = {
+  name: "approval" as const,
   validator: v.union(
     v.object({ approved: v.literal(true), choice: v.number() }),
     v.object({ approved: v.literal(false), reason: v.string() }),
   ),
-});
+} satisfies ValidatedEvent;
 
 const workflow = new WorkflowManager(components.workflow);
 
@@ -50,9 +50,9 @@ export const chooseProposal = internalMutation({
   args: { workflowId: vWorkflowId, choice: v.number() },
   handler: async (ctx, args) => {
     await workflow.sendEvent(ctx, {
-      ...approvalEvent,
       workflowId: args.workflowId,
       value: { approved: true, choice: args.choice },
+      ...approvalEvent,
     });
     return true;
   },

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -346,10 +346,22 @@ export class WorkflowManager {
  */
 export function defineEvent<
   Name extends string,
-  V extends Validator<unknown, "required", string>,
+  V extends Validator<unknown, "required", any>,
 >(spec: { name: Name; validator: V }) {
   return spec;
 }
+
+export type ValidatedEvent<
+  Name extends string = string,
+  V extends Validator<unknown, "required", any> = Validator<
+    unknown,
+    "required",
+    any
+  >,
+> = {
+  name: Name;
+  validator: V;
+};
 
 type RunQueryCtx = {
   runQuery: GenericQueryCtx<GenericDataModel>["runQuery"];


### PR DESCRIPTION
<!-- Describe your PR here. -->

Support both, but point people more towards using a type, which is less surprising to spread, etc.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guidance to recommend using shared object event definitions instead of the previous pattern.

* **New Features**
  * Added a workflow example showcasing an approval flow and conditional handling.

* **Improvements**
  * Introduced a reusable, validated event pattern and stronger typing for events to improve safety and reuse across workflows; updated event send/await usage accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->