### PR TITLE
Allow defining handler after args & returns

### DIFF
--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -8,22 +8,24 @@ import { vResultValidator } from "@convex-dev/workpool";
 
 export const workflow = new WorkflowManager(components.workflow);
 
-export const exampleWorkflow = workflow.define({
-  args: {
-    location: v.string(),
-  },
-  handler: async (
-    step,
-    args,
-    // When returning things from other functions, you need to break the type
-    // inference cycle by specifying the return type explicitly.
-  ): Promise<{
-    name: string;
-    celsius: number;
-    farenheit: number;
-    windSpeed: number;
-    windGust: number;
-  }> => {
+export const exampleWorkflow = workflow
+  .define({
+    args: {
+      location: v.string(),
+    },
+    workpoolOptions: {
+      retryActionsByDefault: true,
+    },
+    // If you also want to run runtime validation on the return value.
+    returns: v.object({
+      name: v.string(),
+      celsius: v.number(),
+      farenheit: v.number(),
+      windSpeed: v.number(),
+      windGust: v.number(),
+    }),
+  })
+  .handler(async (step, args) => {
     console.time("overall");
     console.time("geocoding");
     // Run in parallel!
@@ -54,19 +56,7 @@ export const exampleWorkflow = workflow.define({
     });
     console.timeEnd("overall");
     return { name, celsius, farenheit, windSpeed, windGust };
-  },
-  workpoolOptions: {
-    retryActionsByDefault: true,
-  },
-  // If you also want to run runtime validation on the return value.
-  returns: v.object({
-    name: v.string(),
-    celsius: v.number(),
-    farenheit: v.number(),
-    windSpeed: v.number(),
-    windGust: v.number(),
-  }),
-});
+  });
 
 export const startWorkflow = internalMutation({
   args: {

--- a/example/convex/nestedWorkflow.ts
+++ b/example/convex/nestedWorkflow.ts
@@ -3,9 +3,12 @@ import { workflow } from "./example";
 import { internal } from "./_generated/api";
 import { internalMutation } from "./_generated/server";
 
-export const parentWorkflow = workflow.define({
-  args: { prompt: v.string() },
-  handler: async (ctx, args) => {
+export const parentWorkflow = workflow
+  .define({
+    args: { prompt: v.string() },
+    returns: v.number(),
+  })
+  .handler(async (ctx, args) => {
     console.log("Starting confirmation workflow");
     const length = await ctx.runWorkflow(
       internal.nestedWorkflow.childWorkflow,
@@ -16,12 +19,11 @@ export const parentWorkflow = workflow.define({
       foo: args.prompt,
     });
     console.log("Step result:", stepResult);
-  },
-});
+    return stepResult;
+  });
 
 export const childWorkflow = workflow.define({
   args: { foo: v.string() },
-  returns: v.number(),
   handler: async (_ctx, args) => {
     console.log("Starting nested workflow");
     return args.foo.length;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -17,12 +17,7 @@ import {
   type RegisteredMutation,
   type ReturnValueForOptionalValidator,
 } from "convex/server";
-import type {
-  Infer,
-  ObjectType,
-  PropertyValidators,
-  Validator,
-} from "convex/values";
+import type { ObjectType, PropertyValidators, Validator } from "convex/values";
 import type { Step } from "../component/schema.js";
 import type {
   EventId,
@@ -121,15 +116,59 @@ export class WorkflowManager {
       fn: "You should not call this directly, call workflow.start instead";
       args: ObjectType<ArgsValidator>;
     },
-    ReturnsValidator extends Validator<unknown, "required", string>
-      ? Infer<ReturnsValidator>
-      : void
-  > {
-    return workflowMutation(
-      this.component,
-      workflow,
-      this.options?.workpoolOptions,
-    );
+    ReturnValueForOptionalValidator<ReturnsValidator>
+  >;
+  define<
+    ArgsValidator extends PropertyValidators,
+    ReturnsValidator extends Validator<unknown, "required", string> | void,
+  >(
+    workflow: Omit<
+      WorkflowDefinition<ArgsValidator, ReturnsValidator>,
+      "handler"
+    >,
+  ): {
+    handler: (
+      handler: (
+        step: WorkflowCtx,
+        args: ObjectType<ArgsValidator>,
+      ) => Promise<ReturnValueForOptionalValidator<ReturnsValidator>>,
+    ) => RegisteredMutation<
+      "internal",
+      {
+        fn: "You should not call this directly, call workflow.start instead";
+        args: ObjectType<ArgsValidator>;
+      },
+      ReturnValueForOptionalValidator<ReturnsValidator>
+    >;
+  };
+  define<
+    ArgsValidator extends PropertyValidators,
+    ReturnsValidator extends Validator<unknown, "required", string> | void,
+  >(
+    workflow:
+      | Omit<WorkflowDefinition<ArgsValidator, ReturnsValidator>, "handler">
+      | WorkflowDefinition<ArgsValidator, ReturnsValidator>,
+  ): unknown {
+    if ("handler" in workflow) {
+      return workflowMutation(
+        this.component,
+        workflow,
+        this.options?.workpoolOptions,
+      );
+    }
+    return {
+      handler: (
+        handler: (
+          step: WorkflowCtx,
+          args: ObjectType<ArgsValidator>,
+        ) => Promise<ReturnValueForOptionalValidator<ReturnsValidator>>,
+      ) =>
+        workflowMutation(
+          this.component,
+          { ...workflow, handler },
+          this.options?.workpoolOptions,
+        ),
+    };
   }
 
   /**


### PR DESCRIPTION
<!-- Describe your PR here. -->
Enables:
```ts
export const parentWorkflow = workflow
  .define({
    args: { prompt: v.string() },
    returns: v.number(),
  })
  .handler(async (ctx, args) => {
  ```

Fixes 

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fluent define().handler() workflow syntax for clearer workflow creation.
  * Runtime validation for workflow return values.
  * Configurable workpool options including automatic retries.
  * New exported mutation and adjusted workflow signatures (some workflows now declare return types, others simplified).
  * Ergonomic define API overloads allowing registration with or without an inline handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->