### PR TITLE
feat: integrate BatchWorkpool with workflow step execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,98 @@ const workflow = new WorkflowManager(components.workflow, {
 });
 ```
 
+### High-throughput steps with BatchWorkpool
+
+For workflows that need to run many actions in parallel (e.g., calling an LLM for
+each section of a document), the standard workpool is limited by Convex's action
+concurrency. Each step consumes a separate action slot, so 200 parallel steps
+would require 200 concurrent actions.
+
+`BatchWorkpool` from `@convex-dev/workpool` solves this by running many tasks
+inside a small number of executor actions. A single executor can handle hundreds
+of concurrent async tasks, so 200 parallel steps only need 2-3 action slots.
+
+#### Setup
+
+First, install the workpool component at the app level in your `convex.config.ts`:
+
+```ts
+// convex/convex.config.ts
+import workflow from "@convex-dev/workflow/convex.config.js";
+import workpool from "@convex-dev/workpool/convex.config";
+import { defineApp } from "convex/server";
+
+const app = defineApp();
+app.use(workflow);
+app.use(workpool);
+export default app;
+```
+
+Then create a `BatchWorkpool`, register your actions with `batch.action()`, and
+pass it to `WorkflowManager`:
+
+```ts
+import { BatchWorkpool } from "@convex-dev/workpool";
+import { WorkflowManager } from "@convex-dev/workflow";
+import { components } from "./_generated/api";
+
+// Create batch workpool with the app-level workpool component
+const batch = new BatchWorkpool(components.workpool, {
+  maxWorkers: 2, // number of executor actions
+  maxConcurrencyPerWorker: 200, // async tasks per executor
+});
+
+// Export the executor and wire it up
+export const executor = batch.executor();
+batch.setExecutorRef(executor as any);
+
+// Register actions with batch.action() instead of internalAction()
+export const myAction = batch.action("myAction", {
+  args: { input: v.string() },
+  handler: async (_ctx, args): Promise<string> => {
+    // Your async work here (LLM calls, API requests, etc.)
+    return `Result for ${args.input}`;
+  },
+});
+
+// Pass batch to WorkflowManager
+const workflow = new WorkflowManager(components.workflow, {
+  batch,
+  workpoolOptions: {
+    maxParallelism: 200, // allow many steps per workflow tick
+  },
+});
+```
+
+#### Using batch actions in workflows
+
+Use batch-registered actions in `step.runAction()` exactly like regular actions.
+The workflow automatically routes them through `BatchWorkpool` instead of the
+standard workpool:
+
+```ts
+export const myWorkflow = workflow.define({
+  args: { items: v.array(v.string()) },
+  handler: async (step, args): Promise<string[]> => {
+    // All 200 items run concurrently inside ~2 executor actions
+    const results = await Promise.all(
+      args.items.map((item) =>
+        step.runAction(myAction as any, { input: item }),
+      ),
+    );
+    return results as string[];
+  },
+});
+```
+
+Actions registered with `batch.action()` are automatically detected and routed
+through `BatchWorkpool`. Non-batch actions in the same workflow still go through
+the standard workpool.
+
+See [`example/convex/llmSimulation.ts`](./example/convex/llmSimulation.ts) for a
+complete example comparing regular vs. batched workflow performance with 200
+parallel steps.
+
 ### Checking a workflow's status
 
 The `workflow.start()` method returns a `WorkflowId`, which can then be used for

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as admin from "../admin.js";
 import type * as example from "../example.js";
+import type * as llmSimulation from "../llmSimulation.js";
 import type * as nestedWorkflow from "../nestedWorkflow.js";
 import type * as passingSignals from "../passingSignals.js";
 import type * as transcription from "../transcription.js";
@@ -24,6 +25,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   admin: typeof admin;
   example: typeof example;
+  llmSimulation: typeof llmSimulation;
   nestedWorkflow: typeof nestedWorkflow;
   passingSignals: typeof passingSignals;
   transcription: typeof transcription;
@@ -58,4 +60,5 @@ export declare const internal: FilterApi<
 
 export declare const components: {
   workflow: import("@convex-dev/workflow/_generated/component.js").ComponentApi<"workflow">;
+  workpool: import("@convex-dev/workpool/_generated/component.js").ComponentApi<"workpool">;
 };

--- a/example/convex/convex.config.ts
+++ b/example/convex/convex.config.ts
@@ -1,6 +1,8 @@
 import { defineApp } from "convex/server";
 import workflow from "@convex-dev/workflow/convex.config";
+import workpool from "@convex-dev/workpool/convex.config";
 
 const app = defineApp();
 app.use(workflow);
+app.use(workpool);
 export default app;

--- a/example/convex/llmSimulation.ts
+++ b/example/convex/llmSimulation.ts
@@ -1,0 +1,209 @@
+import { v } from "convex/values";
+import { WorkflowId, WorkflowManager, vWorkflowId } from "@convex-dev/workflow";
+import { BatchWorkpool } from "@convex-dev/workpool";
+import { vResultValidator } from "@convex-dev/workpool";
+import { internal } from "./_generated/api.js";
+import { components } from "./_generated/api.js";
+import { internalMutation, mutation } from "./_generated/server.js";
+import { Id } from "./_generated/dataModel.js";
+
+// --- BatchWorkpool setup ---
+
+const batch = new BatchWorkpool(components.workpool, {
+  maxWorkers: 2,
+  maxConcurrencyPerWorker: 200,
+});
+
+export const executor = batch.executor();
+batch.setExecutorRef(internal.llmSimulation.executor);
+
+// --- Simulated IO actions ---
+
+const SIMULATED_IO_MS = 20_000;
+
+function simulateIO(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export const generateOutline = batch.action("generateOutline", {
+  args: { topic: v.string() },
+  handler: async (_ctx, args): Promise<string[]> => {
+    console.log(`[outline] Generating outline for "${args.topic}"...`);
+    await simulateIO(SIMULATED_IO_MS);
+    const sections: string[] = [];
+    for (let i = 1; i <= 200; i++) {
+      sections.push(`${args.topic} - Section ${i}`);
+    }
+    console.log(`[outline] Generated ${sections.length} section titles`);
+    return sections;
+  },
+});
+
+export const generateSection = batch.action("generateSection", {
+  args: { title: v.string(), index: v.number() },
+  handler: async (_ctx, args): Promise<string> => {
+    console.log(`[section ${args.index}] Generating "${args.title}"...`);
+    await simulateIO(SIMULATED_IO_MS);
+    const content = `Content for "${args.title}": Lorem ipsum dolor sit amet, consectetur adipiscing elit. This is simulated LLM output for section ${args.index}.`;
+    console.log(`[section ${args.index}] Done`);
+    return content;
+  },
+});
+
+export const generateSummary = batch.action("generateSummary", {
+  args: { sectionCount: v.number(), topic: v.string() },
+  handler: async (_ctx, args): Promise<string> => {
+    console.log(
+      `[summary] Summarizing ${args.sectionCount} sections for "${args.topic}"...`,
+    );
+    await simulateIO(SIMULATED_IO_MS);
+    const summary = `Summary of "${args.topic}": This document contains ${args.sectionCount} sections covering the topic in depth. Generated via simulated LLM pipeline.`;
+    console.log(`[summary] Done`);
+    return summary;
+  },
+});
+
+// --- Workflow managers ---
+
+const regularWorkflow = new WorkflowManager(components.workflow);
+
+const batchedWorkflow = new WorkflowManager(components.workflow, {
+  batch,
+});
+
+// --- Shared workflow definition factory ---
+
+function defineContentPipeline(manager: WorkflowManager) {
+  return manager.define({
+    args: { topic: v.string(), simulationId: v.id("llmSimulations") },
+    returns: v.string(),
+    handler: async (step, args): Promise<string> => {
+      // Step 1: Generate outline (~20s)
+      const sections = await step.runAction(
+        internal.llmSimulation.generateOutline,
+        { topic: args.topic },
+      );
+
+      // Step 2: Generate 200 sections in parallel (~20s with batch, much longer with regular)
+      const sectionResults = await Promise.all(
+        (sections as string[]).map((title: string, index: number) =>
+          step.runAction(internal.llmSimulation.generateSection, {
+            title,
+            index,
+          }),
+        ),
+      );
+
+      // Step 3: Generate summary (~20s)
+      const summary = await step.runAction(
+        internal.llmSimulation.generateSummary,
+        {
+          sectionCount: sectionResults.length,
+          topic: args.topic,
+        },
+      );
+
+      // Step 4: Save result
+      await step.runMutation(internal.llmSimulation.saveResult, {
+        simulationId: args.simulationId,
+        result: summary as string,
+      });
+
+      return summary as string;
+    },
+  });
+}
+
+export const regularPipeline = defineContentPipeline(regularWorkflow);
+export const batchedPipeline = defineContentPipeline(batchedWorkflow);
+
+// --- Internal mutations ---
+
+export const saveResult = internalMutation({
+  args: {
+    simulationId: v.id("llmSimulations"),
+    result: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.simulationId, { result: args.result });
+  },
+});
+
+export const pipelineCompleted = internalMutation({
+  args: {
+    workflowId: vWorkflowId,
+    result: vResultValidator,
+    context: v.any(),
+  },
+  handler: async (ctx, args) => {
+    const simulationId = args.context as Id<"llmSimulations">;
+    const simulation = await ctx.db.get(simulationId);
+    if (!simulation) {
+      console.error(`Simulation not found: ${simulationId}`);
+      return;
+    }
+    const completedAt = Date.now();
+    await ctx.db.patch(simulation._id, { completedAt });
+    const elapsed = ((completedAt - simulation.startedAt) / 1000).toFixed(1);
+    console.log(
+      `Pipeline completed [${simulation.mode}]: ${elapsed}s elapsed`,
+    );
+  },
+});
+
+// --- Public start mutations (callable from dashboard) ---
+
+export const startRegularPipeline = mutation({
+  args: {
+    topic: v.optional(v.string()),
+  },
+  returns: v.string(),
+  handler: async (ctx, args): Promise<string> => {
+    const topic = args.topic ?? "The History of Computing";
+    const simulationId = await ctx.db.insert("llmSimulations", {
+      mode: "regular",
+      topic,
+      startedAt: Date.now(),
+    });
+    const workflowId: WorkflowId = await regularWorkflow.start(
+      ctx,
+      internal.llmSimulation.regularPipeline,
+      { topic, simulationId },
+      {
+        onComplete: internal.llmSimulation.pipelineCompleted,
+        context: simulationId,
+        startAsync: true,
+      },
+    );
+    console.log(`Started regular pipeline: ${workflowId}`);
+    return workflowId;
+  },
+});
+
+export const startBatchedPipeline = mutation({
+  args: {
+    topic: v.optional(v.string()),
+  },
+  returns: v.string(),
+  handler: async (ctx, args): Promise<string> => {
+    const topic = args.topic ?? "The History of Computing";
+    const simulationId = await ctx.db.insert("llmSimulations", {
+      mode: "batched",
+      topic,
+      startedAt: Date.now(),
+    });
+    const workflowId: WorkflowId = await batchedWorkflow.start(
+      ctx,
+      internal.llmSimulation.batchedPipeline,
+      { topic, simulationId },
+      {
+        onComplete: internal.llmSimulation.pipelineCompleted,
+        context: simulationId,
+        startAsync: true,
+      },
+    );
+    console.log(`Started batched pipeline: ${workflowId}`);
+    return workflowId;
+  },
+});

--- a/example/convex/llmSimulation.ts
+++ b/example/convex/llmSimulation.ts
@@ -69,6 +69,9 @@ const regularWorkflow = new WorkflowManager(components.workflow);
 
 const batchedWorkflow = new WorkflowManager(components.workflow, {
   batch,
+  workpoolOptions: {
+    maxParallelism: 200,
+  },
 });
 
 // --- Shared workflow definition factory ---
@@ -79,20 +82,28 @@ function defineContentPipeline(manager: WorkflowManager) {
     returns: v.string(),
     handler: async (step, args): Promise<string> => {
       // Step 1: Generate outline (~20s)
-      const sections = await step.runAction(
+      const outline = await step.runAction(
         internal.llmSimulation.generateOutline,
         { topic: args.topic },
       );
+      await step.runMutation(internal.llmSimulation.saveProgress, {
+        simulationId: args.simulationId,
+        outline: outline as string[],
+      });
 
       // Step 2: Generate 200 sections in parallel (~20s with batch, much longer with regular)
       const sectionResults = await Promise.all(
-        (sections as string[]).map((title: string, index: number) =>
+        (outline as string[]).map((title: string, index: number) =>
           step.runAction(internal.llmSimulation.generateSection, {
             title,
             index,
           }),
         ),
       );
+      await step.runMutation(internal.llmSimulation.saveSections, {
+        simulationId: args.simulationId,
+        sections: sectionResults as string[],
+      });
 
       // Step 3: Generate summary (~20s)
       const summary = await step.runAction(
@@ -102,11 +113,9 @@ function defineContentPipeline(manager: WorkflowManager) {
           topic: args.topic,
         },
       );
-
-      // Step 4: Save result
-      await step.runMutation(internal.llmSimulation.saveResult, {
+      await step.runMutation(internal.llmSimulation.saveSummary, {
         simulationId: args.simulationId,
-        result: summary as string,
+        summary: summary as string,
       });
 
       return summary as string;
@@ -119,14 +128,36 @@ export const batchedPipeline = defineContentPipeline(batchedWorkflow);
 
 // --- Internal mutations ---
 
-export const saveResult = internalMutation({
+export const saveProgress = internalMutation({
   args: {
     simulationId: v.id("llmSimulations"),
-    result: v.string(),
+    outline: v.array(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    await ctx.db.patch(args.simulationId, { result: args.result });
+    await ctx.db.patch(args.simulationId, { outline: args.outline });
+  },
+});
+
+export const saveSections = internalMutation({
+  args: {
+    simulationId: v.id("llmSimulations"),
+    sections: v.array(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.simulationId, { sections: args.sections });
+  },
+});
+
+export const saveSummary = internalMutation({
+  args: {
+    simulationId: v.id("llmSimulations"),
+    summary: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.simulationId, { summary: args.summary });
   },
 });
 
@@ -144,7 +175,13 @@ export const pipelineCompleted = internalMutation({
       return;
     }
     const completedAt = Date.now();
-    await ctx.db.patch(simulation._id, { completedAt });
+    const result =
+      args.result.kind === "success"
+        ? String(args.result.returnValue)
+        : args.result.kind === "failed"
+          ? `FAILED: ${args.result.error}`
+          : "CANCELED";
+    await ctx.db.patch(simulation._id, { completedAt, result });
     const elapsed = ((completedAt - simulation.startedAt) / 1000).toFixed(1);
     console.log(
       `Pipeline completed [${simulation.mode}]: ${elapsed}s elapsed`,

--- a/example/convex/llmSimulation.ts
+++ b/example/convex/llmSimulation.ts
@@ -1,7 +1,6 @@
 import { v } from "convex/values";
 import { WorkflowId, WorkflowManager, vWorkflowId } from "@convex-dev/workflow";
-import { BatchWorkpool } from "@convex-dev/workpool";
-import { vResultValidator } from "@convex-dev/workpool";
+import { BatchWorkpool, type RunResult } from "@convex-dev/workpool";
 import { internal } from "./_generated/api.js";
 import { components } from "./_generated/api.js";
 import { internalMutation, mutation } from "./_generated/server.js";
@@ -15,7 +14,7 @@ const batch = new BatchWorkpool(components.workpool, {
 });
 
 export const executor = batch.executor();
-batch.setExecutorRef(internal.llmSimulation.executor);
+batch.setExecutorRef(executor as any);
 
 // --- Simulated IO actions ---
 
@@ -82,10 +81,9 @@ function defineContentPipeline(manager: WorkflowManager) {
     returns: v.string(),
     handler: async (step, args): Promise<string> => {
       // Step 1: Generate outline (~20s)
-      const outline = await step.runAction(
-        internal.llmSimulation.generateOutline,
-        { topic: args.topic },
-      );
+      const outline = await step.runAction(generateOutline as any, {
+        topic: args.topic,
+      });
       await step.runMutation(internal.llmSimulation.saveProgress, {
         simulationId: args.simulationId,
         outline: outline as string[],
@@ -94,7 +92,7 @@ function defineContentPipeline(manager: WorkflowManager) {
       // Step 2: Generate 200 sections in parallel (~20s with batch, much longer with regular)
       const sectionResults = await Promise.all(
         (outline as string[]).map((title: string, index: number) =>
-          step.runAction(internal.llmSimulation.generateSection, {
+          step.runAction(generateSection as any, {
             title,
             index,
           }),
@@ -106,13 +104,10 @@ function defineContentPipeline(manager: WorkflowManager) {
       });
 
       // Step 3: Generate summary (~20s)
-      const summary = await step.runAction(
-        internal.llmSimulation.generateSummary,
-        {
-          sectionCount: sectionResults.length,
-          topic: args.topic,
-        },
-      );
+      const summary = await step.runAction(generateSummary as any, {
+        sectionCount: sectionResults.length,
+        topic: args.topic,
+      });
       await step.runMutation(internal.llmSimulation.saveSummary, {
         simulationId: args.simulationId,
         summary: summary as string,
@@ -164,7 +159,7 @@ export const saveSummary = internalMutation({
 export const pipelineCompleted = internalMutation({
   args: {
     workflowId: vWorkflowId,
-    result: vResultValidator,
+    result: v.any(),
     context: v.any(),
   },
   handler: async (ctx, args) => {
@@ -175,11 +170,12 @@ export const pipelineCompleted = internalMutation({
       return;
     }
     const completedAt = Date.now();
+    const runResult = args.result as RunResult;
     const result =
-      args.result.kind === "success"
-        ? String(args.result.returnValue)
-        : args.result.kind === "failed"
-          ? `FAILED: ${args.result.error}`
+      runResult.kind === "success"
+        ? String(runResult.returnValue)
+        : runResult.kind === "failed"
+          ? `FAILED: ${runResult.error}`
           : "CANCELED";
     await ctx.db.patch(simulation._id, { completedAt, result });
     const elapsed = ((completedAt - simulation.startedAt) / 1000).toFixed(1);
@@ -208,7 +204,7 @@ export const startRegularPipeline = mutation({
       internal.llmSimulation.regularPipeline,
       { topic, simulationId },
       {
-        onComplete: internal.llmSimulation.pipelineCompleted,
+        onComplete: internal.llmSimulation.pipelineCompleted as any,
         context: simulationId,
         startAsync: true,
       },
@@ -235,7 +231,7 @@ export const startBatchedPipeline = mutation({
       internal.llmSimulation.batchedPipeline,
       { topic, simulationId },
       {
-        onComplete: internal.llmSimulation.pipelineCompleted,
+        onComplete: internal.llmSimulation.pipelineCompleted as any,
         context: simulationId,
         startAsync: true,
       },

--- a/example/convex/schema.ts
+++ b/example/convex/schema.ts
@@ -8,4 +8,11 @@ export default defineSchema({
     workflowId: vWorkflowId,
     out: v.any(),
   }).index("workflowId", ["workflowId"]),
+  llmSimulations: defineTable({
+    mode: v.union(v.literal("regular"), v.literal("batched")),
+    topic: v.string(),
+    startedAt: v.number(),
+    completedAt: v.optional(v.number()),
+    result: v.optional(v.string()),
+  }),
 });

--- a/example/convex/schema.ts
+++ b/example/convex/schema.ts
@@ -13,6 +13,9 @@ export default defineSchema({
     topic: v.string(),
     startedAt: v.number(),
     completedAt: v.optional(v.number()),
+    outline: v.optional(v.array(v.string())),
+    sections: v.optional(v.array(v.string())),
+    summary: v.optional(v.string()),
     result: v.optional(v.string()),
   }),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,45 +43,6 @@
         "convex-helpers": "^0.1.99"
       }
     },
-    "../workpool": {
-      "name": "@convex-dev/workpool",
-      "version": "0.3.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "devDependencies": {
-        "@edge-runtime/vm": "5.0.0",
-        "@eslint/eslintrc": "3.3.3",
-        "@eslint/js": "9.39.2",
-        "@types/node": "24.10.11",
-        "@types/react": "19.2.13",
-        "@types/react-dom": "19.2.3",
-        "@vitejs/plugin-react": "5.1.3",
-        "@vitest/coverage-v8": "4.0.18",
-        "chokidar-cli": "3.0.0",
-        "convex": "1.31.7",
-        "convex-helpers": "0.1.111",
-        "convex-test": "0.0.41",
-        "cpy-cli": "7.0.0",
-        "eslint": "9.39.2",
-        "eslint-plugin-react-hooks": "7.0.1",
-        "eslint-plugin-react-refresh": "0.5.0",
-        "globals": "17.3.0",
-        "npm-run-all2": "8.0.4",
-        "path-exists-cli": "2.0.0",
-        "pkg-pr-new": "0.0.63",
-        "prettier": "3.8.1",
-        "react": "19.2.4",
-        "react-dom": "19.2.4",
-        "typescript": "5.9.3",
-        "typescript-eslint": "8.54.0",
-        "vite": "7.3.1",
-        "vitest": "4.0.18"
-      },
-      "peerDependencies": {
-        "convex": "^1.24.8",
-        "convex-helpers": "^0.1.94"
-      }
-    },
     "node_modules/@actions/core": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
@@ -389,8 +350,14 @@
       }
     },
     "node_modules/@convex-dev/workpool": {
-      "resolved": "../workpool",
-      "link": true
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@convex-dev/workpool/-/workpool-0.3.1.tgz",
+      "integrity": "sha512-uw4Mi+irhhoYA/KwaMo5wXyYJ7BbxqeaLcCZbst3t1SxPN5488rpnR0OwBcPDCmwcdQjBVHOx+q8S4GUjq0Csg==",
+      "dev": true,
+      "peerDependencies": {
+        "convex": "^1.24.8",
+        "convex-helpers": "^0.1.94"
+      }
     },
     "node_modules/@edge-runtime/primitives": {
       "version": "6.0.0",
@@ -416,14 +383,13 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
-      "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -433,14 +399,13 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
-      "integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -450,14 +415,13 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
-      "integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -467,14 +431,13 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
-      "integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -484,14 +447,13 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
-      "integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -501,14 +463,13 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
-      "integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -518,14 +479,13 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -535,14 +495,13 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
-      "integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -552,14 +511,13 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
-      "integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -569,14 +527,13 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
-      "integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -586,14 +543,13 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
-      "integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -603,14 +559,13 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
-      "integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -620,14 +575,13 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
-      "integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -637,14 +591,13 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
-      "integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -654,14 +607,13 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
-      "integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -671,14 +623,13 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
-      "integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -688,14 +639,13 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
-      "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -705,14 +655,13 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -722,14 +671,13 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
-      "integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -739,14 +687,13 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -756,14 +703,13 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
-      "integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -790,14 +736,13 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
-      "integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -807,14 +752,13 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
-      "integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -824,14 +768,13 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
-      "integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -841,14 +784,13 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
-      "integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2214,6 +2156,15 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2301,9 +2252,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2541,29 +2492,6 @@
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
         "wrap-ansi": "^5.1.0"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -3333,12 +3261,11 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
-      "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3346,31 +3273,48 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.4",
-        "@esbuild/android-arm": "0.25.4",
-        "@esbuild/android-arm64": "0.25.4",
-        "@esbuild/android-x64": "0.25.4",
-        "@esbuild/darwin-arm64": "0.25.4",
-        "@esbuild/darwin-x64": "0.25.4",
-        "@esbuild/freebsd-arm64": "0.25.4",
-        "@esbuild/freebsd-x64": "0.25.4",
-        "@esbuild/linux-arm": "0.25.4",
-        "@esbuild/linux-arm64": "0.25.4",
-        "@esbuild/linux-ia32": "0.25.4",
-        "@esbuild/linux-loong64": "0.25.4",
-        "@esbuild/linux-mips64el": "0.25.4",
-        "@esbuild/linux-ppc64": "0.25.4",
-        "@esbuild/linux-riscv64": "0.25.4",
-        "@esbuild/linux-s390x": "0.25.4",
-        "@esbuild/linux-x64": "0.25.4",
-        "@esbuild/netbsd-arm64": "0.25.4",
-        "@esbuild/netbsd-x64": "0.25.4",
-        "@esbuild/openbsd-arm64": "0.25.4",
-        "@esbuild/openbsd-x64": "0.25.4",
-        "@esbuild/sunos-x64": "0.25.4",
-        "@esbuild/win32-arm64": "0.25.4",
-        "@esbuild/win32-ia32": "0.25.4",
-        "@esbuild/win32-x64": "0.25.4"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/escalade": {
@@ -4460,11 +4404,10 @@
       }
     },
     "node_modules/npm-run-all2/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -4473,21 +4416,19 @@
       }
     },
     "node_modules/npm-run-all2/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
       "dev": true,
-      "license": "ISC",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/npm-run-all2/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -4996,11 +4937,10 @@
       "license": "MIT"
     },
     "node_modules/quick-lru": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.0.1.tgz",
-      "integrity": "sha512-kLjThirJMkWKutUKbZ8ViqFc09tDQhlbQo2MNuVeLWbRauqYP96Sm6nzlQ24F0HFjUNZ4i9+AgldJ9H6DZXi7g==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.3.0.tgz",
+      "integrity": "sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -5191,11 +5131,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5360,22 +5299,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -5806,11 +5734,13 @@
       }
     },
     "node_modules/vite/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -5821,11 +5751,10 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -5986,16 +5915,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -6025,19 +5944,6 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "async-channel": "^0.2.0"
       },
       "devDependencies": {
-        "@convex-dev/workpool": "0.3.1",
+        "@convex-dev/workpool": "https://pkg.pr.new/get-convex/workpool/@convex-dev/workpool@167",
         "@edge-runtime/vm": "5.0.0",
         "@eslint/eslintrc": "3.3.3",
         "@eslint/js": "9.39.2",
@@ -351,9 +351,10 @@
     },
     "node_modules/@convex-dev/workpool": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@convex-dev/workpool/-/workpool-0.3.1.tgz",
-      "integrity": "sha512-uw4Mi+irhhoYA/KwaMo5wXyYJ7BbxqeaLcCZbst3t1SxPN5488rpnR0OwBcPDCmwcdQjBVHOx+q8S4GUjq0Csg==",
+      "resolved": "https://pkg.pr.new/get-convex/workpool/@convex-dev/workpool@167",
+      "integrity": "sha512-rE0g3TM5RzQK8AiqrekyzFmZl8q9GQmciza6VoHAsABKQ2qQv9GDNiWMs0kqtGuju/C/xrurm+12BL+ezWXz6w==",
       "dev": true,
+      "license": "Apache-2.0",
       "peerDependencies": {
         "convex": "^1.24.8",
         "convex-helpers": "^0.1.94"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "async-channel": "^0.2.0"
       },
       "devDependencies": {
-        "@convex-dev/workpool": "0.3.1",
+        "@convex-dev/workpool": "file:../workpool",
         "@edge-runtime/vm": "5.0.0",
         "@eslint/eslintrc": "3.3.3",
         "@eslint/js": "9.39.2",
@@ -41,6 +41,44 @@
         "@convex-dev/workpool": "^0.3.0",
         "convex": "^1.24.8",
         "convex-helpers": "^0.1.99"
+      }
+    },
+    "../workpool": {
+      "version": "0.3.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@edge-runtime/vm": "5.0.0",
+        "@eslint/eslintrc": "3.3.3",
+        "@eslint/js": "9.39.2",
+        "@types/node": "24.10.11",
+        "@types/react": "19.2.13",
+        "@types/react-dom": "19.2.3",
+        "@vitejs/plugin-react": "5.1.3",
+        "@vitest/coverage-v8": "4.0.18",
+        "chokidar-cli": "3.0.0",
+        "convex": "1.31.7",
+        "convex-helpers": "0.1.111",
+        "convex-test": "0.0.41",
+        "cpy-cli": "7.0.0",
+        "eslint": "9.39.2",
+        "eslint-plugin-react-hooks": "7.0.1",
+        "eslint-plugin-react-refresh": "0.5.0",
+        "globals": "17.3.0",
+        "npm-run-all2": "8.0.4",
+        "path-exists-cli": "2.0.0",
+        "pkg-pr-new": "0.0.63",
+        "prettier": "3.8.1",
+        "react": "19.2.4",
+        "react-dom": "19.2.4",
+        "typescript": "5.9.3",
+        "typescript-eslint": "8.54.0",
+        "vite": "7.3.1",
+        "vitest": "4.0.18"
+      },
+      "peerDependencies": {
+        "convex": "^1.24.8",
+        "convex-helpers": "^0.1.94"
       }
     },
     "node_modules/@actions/core": {
@@ -120,7 +158,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -351,15 +388,8 @@
       }
     },
     "node_modules/@convex-dev/workpool": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@convex-dev/workpool/-/workpool-0.3.1.tgz",
-      "integrity": "sha512-uw4Mi+irhhoYA/KwaMo5wXyYJ7BbxqeaLcCZbst3t1SxPN5488rpnR0OwBcPDCmwcdQjBVHOx+q8S4GUjq0Csg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "convex": "^1.24.8",
-        "convex-helpers": "^0.1.94"
-      }
+      "resolved": "../workpool",
+      "link": true
     },
     "node_modules/@edge-runtime/primitives": {
       "version": "6.0.0",
@@ -377,7 +407,6 @@
       "integrity": "sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@edge-runtime/primitives": "6.0.0"
       },
@@ -1217,7 +1246,6 @@
       "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -1723,8 +1751,7 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -1770,7 +1797,6 @@
       "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1827,7 +1853,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2156,7 +2181,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2317,7 +2341,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -2586,7 +2609,6 @@
       "integrity": "sha512-PtNMe1mAIOvA8Yz100QTOaIdgt2rIuWqencVXrb4McdhxBHZ8IJ1eXTnrgCC9HydyilGT1pOn+KNqT14mqn9fQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0"
@@ -2621,7 +2643,6 @@
       "integrity": "sha512-0O59Ohi8HVc3+KULxSC6JHsw8cQJyc8gZ7OAfNRVX7T5Wy6LhPx3l8veYN9avKg7UiPlO7m1eBiQMHKclIyXyQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "convex-helpers": "bin.cjs"
       },
@@ -3379,7 +3400,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5456,7 +5476,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5563,7 +5582,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5717,7 +5735,6 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5808,7 +5825,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6156,7 +6172,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "async-channel": "^0.2.0"
       },
       "devDependencies": {
-        "@convex-dev/workpool": "file:../workpool",
+        "@convex-dev/workpool": "0.3.1",
         "@edge-runtime/vm": "5.0.0",
         "@eslint/eslintrc": "3.3.3",
         "@eslint/js": "9.39.2",
@@ -44,6 +44,7 @@
       }
     },
     "../workpool": {
+      "name": "@convex-dev/workpool",
       "version": "0.3.1",
       "dev": true,
       "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "async-channel": "^0.2.0"
   },
   "devDependencies": {
-    "@convex-dev/workpool": "0.3.1",
+    "@convex-dev/workpool": "https://pkg.pr.new/get-convex/workpool/@convex-dev/workpool@167",
     "@edge-runtime/vm": "5.0.0",
     "@eslint/eslintrc": "3.3.3",
     "@eslint/js": "9.39.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "async-channel": "^0.2.0"
   },
   "devDependencies": {
-    "@convex-dev/workpool": "file:../workpool",
+    "@convex-dev/workpool": "0.3.1",
     "@edge-runtime/vm": "5.0.0",
     "@eslint/eslintrc": "3.3.3",
     "@eslint/js": "9.39.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "async-channel": "^0.2.0"
   },
   "devDependencies": {
-    "@convex-dev/workpool": "0.3.1",
+    "@convex-dev/workpool": "file:../workpool",
     "@edge-runtime/vm": "5.0.0",
     "@eslint/eslintrc": "3.3.3",
     "@eslint/js": "9.39.2",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,4 +1,5 @@
 import type {
+  BatchWorkpool,
   RunResult,
   WorkpoolOptions,
   WorkpoolRetryOptions,
@@ -100,7 +101,8 @@ export class WorkflowManager {
   constructor(
     public component: WorkflowComponent,
     public options?: {
-      workpoolOptions: WorkpoolOptions;
+      workpoolOptions?: WorkpoolOptions;
+      batch?: BatchWorkpool;
     },
   ) {}
 
@@ -129,6 +131,7 @@ export class WorkflowManager {
       this.component,
       workflow,
       this.options?.workpoolOptions,
+      this.options?.batch,
     );
   }
 

--- a/src/client/step.test.ts
+++ b/src/client/step.test.ts
@@ -556,3 +556,721 @@ describe("StepExecutor.run batchGroup replay", () => {
     expect(msg2.reject).toHaveBeenCalledWith(new Error("Canceled"));
   });
 });
+
+// ==========================================================================
+// Black-box tests: designed from the spec without reading the implementation.
+// Goal: find bugs by testing edge cases and tricky scenarios.
+// ==========================================================================
+
+describe("batchGroup edge cases (black-box)", () => {
+  // --- Replay edge cases ---
+
+  it("replays batchGroup with count=1 (single item batch)", async () => {
+    const bgEntry = fakeBatchGroupEntry(0, 1);
+    const { executor, channel, setMockBatchResults } = createExecutor({
+      journalEntries: [bgEntry],
+    });
+
+    setMockBatchResults([
+      { index: 0, result: { kind: "success", returnValue: "only" } },
+    ]);
+
+    const msg = actionMessage("s0", "module:action");
+    const msgBlock = actionMessage("block", "module:action");
+    await channel.push(msg);
+    await channel.push(msgBlock);
+
+    const result = await executor.run();
+    expect(result.type).toBe("executorBlocked");
+    expect(msg.resolve).toHaveBeenCalledWith("only");
+    expect(msg.reject).not.toHaveBeenCalled();
+  });
+
+  it("replays two consecutive batchGroup entries", async () => {
+    // Two batchGroups back-to-back: first has 2 items, second has 3 items
+    const bg1 = fakeBatchGroupEntry(0, 2);
+    const bg2 = fakeBatchGroupEntry(1, 3);
+    // Give them distinct IDs
+    (bg2 as any)._id = "step_bg_1";
+
+    // We need loadBatchResults to return different results for different step IDs.
+    // The mock currently returns one fixed array. Let's use a per-call approach.
+    const callLog: string[] = [];
+    let batchResultsMap: Record<
+      string,
+      Array<{
+        index: number;
+        result: { kind: string; returnValue?: unknown; error?: string };
+      }>
+    > = {};
+
+    batchResultsMap["step_bg_0"] = [
+      { index: 0, result: { kind: "success", returnValue: "bg1_item0" } },
+      { index: 1, result: { kind: "success", returnValue: "bg1_item1" } },
+    ];
+    batchResultsMap["step_bg_1"] = [
+      { index: 0, result: { kind: "success", returnValue: "bg2_item0" } },
+      { index: 1, result: { kind: "success", returnValue: "bg2_item1" } },
+      { index: 2, result: { kind: "success", returnValue: "bg2_item2" } },
+    ];
+
+    const mockComponent = {
+      journal: {
+        startSteps: { __type: "startSteps" } as any,
+        startBatchSteps: { __type: "startBatchSteps" } as any,
+        startBatchGroupStep: { __type: "startBatchGroupStep" } as any,
+        loadBatchResults: { __type: "loadBatchResults" } as any,
+      },
+    } as any;
+
+    let stepCounter = 100;
+    const mockCtx = {
+      runMutation: vi.fn(async (_ref: any, mutArgs: any) => {
+        // Handle startSteps for the blocking message
+        if (_ref === mockComponent.journal.startSteps) {
+          return mutArgs.steps.map((s: any) =>
+            fakeEntry(stepCounter++, s.step.name),
+          );
+        }
+        return null;
+      }),
+      runQuery: vi.fn(async (_ref: any, args: any) => {
+        if (_ref === mockComponent.journal.loadBatchResults) {
+          callLog.push(args.batchStepId);
+          return batchResultsMap[args.batchStepId] ?? [];
+        }
+        return [];
+      }),
+    } as any;
+
+    const channel = new BaseChannel<StepRequest>(100);
+    const executor = new StepExecutor(
+      "wf_test",
+      1,
+      mockCtx,
+      mockComponent,
+      [bg1, bg2],
+      channel,
+      Date.now(),
+      undefined,
+      undefined,
+    );
+
+    // 2 messages for bg1 + 3 messages for bg2 + 1 blocking message
+    const msgs = Array.from({ length: 6 }, (_, i) =>
+      actionMessage(`s${i}`, "module:action"),
+    );
+    for (const m of msgs) await channel.push(m);
+
+    const result = await executor.run();
+
+    expect(result.type).toBe("executorBlocked");
+    // loadBatchResults should have been called for both batchGroup entries
+    expect(callLog).toEqual(["step_bg_0", "step_bg_1"]);
+    // First batchGroup: messages 0,1
+    expect(msgs[0].resolve).toHaveBeenCalledWith("bg1_item0");
+    expect(msgs[1].resolve).toHaveBeenCalledWith("bg1_item1");
+    // Second batchGroup: messages 2,3,4
+    expect(msgs[2].resolve).toHaveBeenCalledWith("bg2_item0");
+    expect(msgs[3].resolve).toHaveBeenCalledWith("bg2_item1");
+    expect(msgs[4].resolve).toHaveBeenCalledWith("bg2_item2");
+  });
+
+  it("sorts results by index even when returned out of order", async () => {
+    const bgEntry = fakeBatchGroupEntry(0, 3);
+    const { executor, channel, setMockBatchResults } = createExecutor({
+      journalEntries: [bgEntry],
+    });
+
+    // Results returned in scrambled order: 2, 0, 1
+    setMockBatchResults([
+      { index: 2, result: { kind: "success", returnValue: "two" } },
+      { index: 0, result: { kind: "success", returnValue: "zero" } },
+      { index: 1, result: { kind: "success", returnValue: "one" } },
+    ]);
+
+    const msg0 = actionMessage("s0", "module:action");
+    const msg1 = actionMessage("s1", "module:action");
+    const msg2 = actionMessage("s2", "module:action");
+    const msgBlock = actionMessage("block", "module:action");
+    await channel.push(msg0);
+    await channel.push(msg1);
+    await channel.push(msg2);
+    await channel.push(msgBlock);
+
+    const result = await executor.run();
+
+    expect(result.type).toBe("executorBlocked");
+    // Results must be matched by index, not by arrival order
+    expect(msg0.resolve).toHaveBeenCalledWith("zero");
+    expect(msg1.resolve).toHaveBeenCalledWith("one");
+    expect(msg2.resolve).toHaveBeenCalledWith("two");
+  });
+
+  it("handles batchGroup where all items fail", async () => {
+    const bgEntry = fakeBatchGroupEntry(0, 2);
+    const { executor, channel, setMockBatchResults } = createExecutor({
+      journalEntries: [bgEntry],
+    });
+
+    setMockBatchResults([
+      { index: 0, result: { kind: "failed", error: "boom0" } },
+      { index: 1, result: { kind: "failed", error: "boom1" } },
+    ]);
+
+    const msg0 = actionMessage("s0", "module:action");
+    const msg1 = actionMessage("s1", "module:action");
+    const msgBlock = actionMessage("block", "module:action");
+    await channel.push(msg0);
+    await channel.push(msg1);
+    await channel.push(msgBlock);
+
+    const result = await executor.run();
+
+    expect(result.type).toBe("executorBlocked");
+    expect(msg0.resolve).not.toHaveBeenCalled();
+    expect(msg1.resolve).not.toHaveBeenCalled();
+    expect(msg0.reject).toHaveBeenCalledWith(new Error("boom0"));
+    expect(msg1.reject).toHaveBeenCalledWith(new Error("boom1"));
+  });
+
+  it("throws if batchGroup entry is still in progress during replay", async () => {
+    // A batchGroup entry that hasn't completed yet should not be replayed
+    const bgEntry = fakeBatchGroupEntry(0, 2, { inProgress: true });
+    const { executor, channel } = createExecutor({
+      journalEntries: [bgEntry],
+    });
+
+    const msg = actionMessage("s0", "module:action");
+    const msgBlock = actionMessage("block", "module:action");
+    await channel.push(msg);
+    await channel.push(msgBlock);
+
+    // Should throw or return executorBlocked (since in-progress means blocked)
+    await expect(executor.run()).rejects.toThrow();
+  });
+
+  it("replays batchGroup followed by regular entry then another batchGroup", async () => {
+    // bg(2) -> regular -> bg(1)
+    const bg1 = fakeBatchGroupEntry(0, 2);
+    const regular: JournalEntry = {
+      _id: "step_r1",
+      _creationTime: Date.now(),
+      workflowId: "wf_test" as any,
+      stepNumber: 1,
+      step: {
+        kind: "function" as const,
+        functionType: "action" as const,
+        handle: "function://test",
+        name: "middle",
+        inProgress: false,
+        argsSize: 2,
+        args: {},
+        runResult: { kind: "success" as const, returnValue: "mid" },
+        startedAt: Date.now(),
+        completedAt: Date.now(),
+      },
+    };
+    const bg2 = fakeBatchGroupEntry(2, 1);
+    (bg2 as any)._id = "step_bg_2";
+
+    const mockComponent = {
+      journal: {
+        startSteps: { __type: "startSteps" } as any,
+        startBatchSteps: { __type: "startBatchSteps" } as any,
+        startBatchGroupStep: { __type: "startBatchGroupStep" } as any,
+        loadBatchResults: { __type: "loadBatchResults" } as any,
+      },
+    } as any;
+
+    const batchResultsMap: Record<string, any[]> = {
+      step_bg_0: [
+        { index: 0, result: { kind: "success", returnValue: "b1_0" } },
+        { index: 1, result: { kind: "success", returnValue: "b1_1" } },
+      ],
+      step_bg_2: [
+        { index: 0, result: { kind: "success", returnValue: "b2_0" } },
+      ],
+    };
+
+    let stepCounter = 100;
+    const mockCtx = {
+      runMutation: vi.fn(async (_ref: any, mutArgs: any) => {
+        if (_ref === mockComponent.journal.startSteps) {
+          return mutArgs.steps.map((s: any) =>
+            fakeEntry(stepCounter++, s.step.name),
+          );
+        }
+        return null;
+      }),
+      runQuery: vi.fn(async (_ref: any, args: any) => {
+        if (_ref === mockComponent.journal.loadBatchResults) {
+          return batchResultsMap[args.batchStepId] ?? [];
+        }
+        return [];
+      }),
+    } as any;
+
+    const channel = new BaseChannel<StepRequest>(100);
+    const executor = new StepExecutor(
+      "wf_test",
+      1,
+      mockCtx,
+      mockComponent,
+      [bg1, regular, bg2],
+      channel,
+      Date.now(),
+      undefined,
+      undefined,
+    );
+
+    // bg1: 2 msgs, regular: 1 msg, bg2: 1 msg, + 1 blocking
+    const msgs = Array.from({ length: 5 }, (_, i) =>
+      actionMessage(`s${i}`, "module:action"),
+    );
+    for (const m of msgs) await channel.push(m);
+
+    const result = await executor.run();
+
+    expect(result.type).toBe("executorBlocked");
+    expect(msgs[0].resolve).toHaveBeenCalledWith("b1_0");
+    expect(msgs[1].resolve).toHaveBeenCalledWith("b1_1");
+    expect(msgs[2].resolve).toHaveBeenCalledWith("mid");
+    expect(msgs[3].resolve).toHaveBeenCalledWith("b2_0");
+  });
+
+  // --- startSteps edge cases ---
+
+  it("single batch-eligible action creates batchGroup with count=1, uses enqueueByHandle not enqueueBatch", async () => {
+    const batch = createMockBatch(["module:batchAction"]);
+    const { executor, callLog } = createExecutor({ batch });
+
+    const messages = [actionMessage("solo", "module:batchAction", { x: 1 })];
+
+    const entries = await executor.startSteps(messages);
+
+    // Should create a batchGroup with count=1
+    expect(callLog).toHaveLength(1);
+    expect(callLog[0]).toMatchObject({
+      mutation: "startBatchGroupStep",
+      count: 1,
+    });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].step.kind).toBe("batchGroup");
+
+    // For a single item batch, enqueueByHandle should be used (not enqueueBatch)
+    // so batchEnqueueBatch should NOT appear in callLog
+    expect(callLog.every((c) => c.mutation !== "batchEnqueueBatch")).toBe(true);
+    expect(batch.enqueueByHandle).toHaveBeenCalledTimes(1);
+  });
+
+  it("large batch (100 items) creates single batchGroup entry", async () => {
+    const batch = createMockBatch(["module:batchAction"]);
+    const { executor, callLog } = createExecutor({ batch });
+
+    const messages = Array.from({ length: 100 }, (_, i) =>
+      actionMessage(`step${i}`, "module:batchAction", { i }),
+    );
+
+    const entries = await executor.startSteps(messages);
+
+    // Should be: startBatchGroupStep + batchEnqueueBatch (for 99 remaining items)
+    const bgCalls = callLog.filter(
+      (c) => c.mutation === "startBatchGroupStep",
+    );
+    expect(bgCalls).toHaveLength(1);
+    expect(bgCalls[0].count).toBe(100);
+
+    // Only 1 journal entry
+    expect(entries).toHaveLength(1);
+
+    // enqueueByHandle for the first item
+    expect(batch.enqueueByHandle).toHaveBeenCalledTimes(1);
+  });
+
+  it("batch items have correct context with batchStepId and sequential index", async () => {
+    const batch = createMockBatch(["module:batchAction"]);
+    const { executor } = createExecutor({ batch });
+
+    const messages = [
+      actionMessage("s0", "module:batchAction", { val: "a" }),
+      actionMessage("s1", "module:batchAction", { val: "b" }),
+      actionMessage("s2", "module:batchAction", { val: "c" }),
+    ];
+
+    await executor.startSteps(messages);
+
+    // The first item goes through enqueueByHandle
+    const enqueueByHandle = batch.enqueueByHandle as ReturnType<typeof vi.fn>;
+    expect(enqueueByHandle).toHaveBeenCalledTimes(1);
+    const firstCallArgs = enqueueByHandle.mock.calls[0];
+    // enqueueByHandle(ctx, name, args, options)
+    // options.onComplete should contain context with batchStepId and index: 0
+    const firstOptions = firstCallArgs[3];
+    expect(firstOptions.onComplete).toBeDefined();
+    expect(firstOptions.onComplete.context).toBeDefined();
+    expect(firstOptions.onComplete.context.index).toBe(0);
+    expect(firstOptions.onComplete.context.batchStepId).toBeDefined();
+  });
+
+  it("batchGroup replay with results having non-contiguous indices panics or handles gracefully", async () => {
+    // What if results have indices [0, 2] for count=3 (missing index 1)?
+    // The sort-by-index approach would put them at positions 0 and 1 in the sorted
+    // array, but result[1] would be for index 2, not index 1. And result[2] would
+    // be undefined. This should either be handled gracefully or detected as an error.
+    const bgEntry = fakeBatchGroupEntry(0, 3);
+    const { executor, channel, setMockBatchResults } = createExecutor({
+      journalEntries: [bgEntry],
+    });
+
+    // Only 2 results for count=3 (missing index 1)
+    setMockBatchResults([
+      { index: 0, result: { kind: "success", returnValue: "zero" } },
+      { index: 2, result: { kind: "success", returnValue: "two" } },
+    ]);
+
+    const msg0 = actionMessage("s0", "module:action");
+    const msg1 = actionMessage("s1", "module:action");
+    const msg2 = actionMessage("s2", "module:action");
+    const msgBlock = actionMessage("block", "module:action");
+    await channel.push(msg0);
+    await channel.push(msg1);
+    await channel.push(msg2);
+    await channel.push(msgBlock);
+
+    // This should either throw (missing result) or handle gracefully.
+    // It should NOT silently assign the wrong result to the wrong message.
+    // If it sorts by index and accesses by array position, msg1 gets result
+    // for index 2 (wrong!) and msg2 gets undefined (crash!).
+    try {
+      const result = await executor.run();
+      // If it doesn't throw, at least verify results are correct
+      // msg0 -> index 0 result
+      expect(msg0.resolve).toHaveBeenCalledWith("zero");
+      // msg1 should NOT get index 2's result
+      if (msg1.resolve.mock.calls.length > 0) {
+        // If it resolved, it should not be "two" (that's for index 2)
+        expect(msg1.resolve).not.toHaveBeenCalledWith("two");
+      }
+    } catch {
+      // Throwing is acceptable — missing results is an error condition
+    }
+  });
+
+  it("batchGroup replay with duplicate indices gives wrong results", async () => {
+    // What if results have duplicate indices? [0, 0, 1] for count=3
+    // After sorting, both index-0 results end up first. Only 3 items in array
+    // but the third may resolve with index 1's result, missing index 2 entirely.
+    const bgEntry = fakeBatchGroupEntry(0, 3);
+    const { executor, channel, setMockBatchResults } = createExecutor({
+      journalEntries: [bgEntry],
+    });
+
+    // Duplicate index 0, no index 2
+    setMockBatchResults([
+      { index: 0, result: { kind: "success", returnValue: "first_zero" } },
+      { index: 0, result: { kind: "success", returnValue: "dup_zero" } },
+      { index: 1, result: { kind: "success", returnValue: "one" } },
+    ]);
+
+    const msg0 = actionMessage("s0", "module:action");
+    const msg1 = actionMessage("s1", "module:action");
+    const msg2 = actionMessage("s2", "module:action");
+    const msgBlock = actionMessage("block", "module:action");
+    await channel.push(msg0);
+    await channel.push(msg1);
+    await channel.push(msg2);
+    await channel.push(msgBlock);
+
+    // This should ideally be caught as an error condition.
+    // But the implementation may silently assign wrong results.
+    try {
+      await executor.run();
+      // msg2 should have gotten index 2's result, but there is no index 2.
+      // If it resolved at all, something is wrong.
+      if (msg2.resolve.mock.calls.length > 0) {
+        // What did it resolve with? If "one" then index matching is broken.
+        const resolvedValue = msg2.resolve.mock.calls[0][0];
+        // There IS no result for index 2 — any resolution is suspect.
+        // This test documents the behavior even if it doesn't crash.
+        expect(resolvedValue).toBeDefined();
+      }
+    } catch {
+      // Acceptable
+    }
+  });
+
+  it("batchGroup enqueue passes correct onComplete handle to all items", async () => {
+    const batch = createMockBatch(["module:batchAction"]);
+    const enqueueBatchMock = vi.fn(async (tasks: any[]) =>
+      tasks.map(() => "task_id"),
+    );
+    // Override the component's enqueueBatch to capture the calls
+    (batch as any).component.batch.enqueueBatch = {
+      __type: "enqueueBatch",
+    } as any;
+
+    const { executor, mockCtx } = createExecutor({ batch });
+
+    const messages = [
+      actionMessage("s0", "module:batchAction"),
+      actionMessage("s1", "module:batchAction"),
+      actionMessage("s2", "module:batchAction"),
+    ];
+
+    await executor.startSteps(messages);
+
+    // Check that the batch enqueue mutation was called with correct onComplete
+    const batchCalls = mockCtx.runMutation.mock.calls.filter(
+      ([ref]: any[]) => ref.__type === "enqueueBatch",
+    );
+    if (batchCalls.length > 0) {
+      const tasks = batchCalls[0][1].tasks;
+      // Each task should have onComplete pointing to the batchGroupItem handler
+      for (const task of tasks) {
+        expect(task.onComplete).toBeDefined();
+      }
+    }
+  });
+
+  it("regular steps after batchGroup in startSteps get correct entries", async () => {
+    // batch(2) then regular(2) in a single startSteps call
+    const batch = createMockBatch(["module:batchAction"]);
+    const { executor, callLog } = createExecutor({ batch });
+
+    const messages = [
+      actionMessage("b0", "module:batchAction"),
+      actionMessage("b1", "module:batchAction"),
+      mutationMessage("r0", "module:mutation"),
+      mutationMessage("r1", "module:mutation"),
+    ];
+
+    const entries = await executor.startSteps(messages);
+
+    // Should be: batchGroup(count=2) -> startSteps([r0, r1])
+    expect(callLog[0]).toMatchObject({
+      mutation: "startBatchGroupStep",
+      count: 2,
+    });
+    expect(callLog.find((c) => c.mutation === "startSteps")).toMatchObject({
+      mutation: "startSteps",
+      names: ["r0", "r1"],
+    });
+
+    // 1 batchGroup + 2 regular = 3 entries
+    expect(entries).toHaveLength(3);
+    // Verify the ordering: batchGroup first, then the two regular entries
+    expect(entries[0].step.kind).toBe("batchGroup");
+    expect(entries[1].step.kind).toBe("function");
+    expect(entries[2].step.kind).toBe("function");
+    expect(entries[1].step.name).toBe("r0");
+    expect(entries[2].step.name).toBe("r1");
+  });
+
+  it("startSteps with only non-action messages + batch configured falls back to regular", async () => {
+    const batch = createMockBatch(["module:anything"]);
+    const { executor, callLog } = createExecutor({ batch });
+
+    // Event-type messages (not function kind)
+    const eventMsg: StepRequest = {
+      name: "myEvent",
+      target: { kind: "event", args: { eventId: "evt_123" as any } },
+      retry: undefined,
+      schedulerOptions: {},
+      resolve: vi.fn(),
+      reject: vi.fn(),
+    };
+
+    const entries = await executor.startSteps([eventMsg]);
+
+    // Events should go through regular startSteps, not batchGroup
+    expect(callLog).toHaveLength(1);
+    expect(callLog[0].mutation).toBe("startSteps");
+  });
+
+  it("startSteps with workflow-kind messages + batch configured falls back to regular", async () => {
+    const batch = createMockBatch(["module:anything"]);
+    const { executor, callLog } = createExecutor({ batch });
+
+    const workflowMsg: StepRequest = {
+      name: "nestedWf",
+      target: {
+        kind: "workflow",
+        function: mockFnRef("module:nestedWorkflow"),
+        args: {},
+      },
+      retry: undefined,
+      schedulerOptions: {},
+      resolve: vi.fn(),
+      reject: vi.fn(),
+    };
+
+    const entries = await executor.startSteps([workflowMsg]);
+
+    // Workflows should go through regular startSteps, not batchGroup
+    expect(callLog).toHaveLength(1);
+    expect(callLog[0].mutation).toBe("startSteps");
+  });
+});
+
+// ==========================================================================
+// Bug-hunting tests: written after reading the implementation to target
+// specific code paths that look fragile.
+// ==========================================================================
+
+describe("batchGroup bug hunting", () => {
+  it("entries/messages length mismatch: batchGroup entry must not have runResult", async () => {
+    // When startSteps returns a mix of batchGroup and regular entries,
+    // entries.length < messages.length (1 batchGroup entry for N messages).
+    // If entries.every(e => e.step.runResult) were true, the code would
+    // iterate with messages[i]/entries[i] which are mismatched.
+    //
+    // This test guards the invariant that batchGroup entries from startSteps
+    // never have runResult set. If this fails, the entries[i]/messages[i]
+    // loop in run() would silently assign wrong results.
+    const batch = createMockBatch(["module:batchAction"]);
+    const { executor } = createExecutor({ batch });
+
+    const messages = [
+      actionMessage("b0", "module:batchAction"),
+      actionMessage("b1", "module:batchAction"),
+      mutationMessage("r0", "module:mutation"),
+    ];
+
+    const entries = await executor.startSteps(messages);
+
+    // 3 messages but only 2 entries (1 batchGroup + 1 regular)
+    expect(entries).toHaveLength(2);
+    expect(messages).toHaveLength(3);
+    // CRITICAL INVARIANT: batchGroup entry must NOT have runResult set
+    const bgEntry = entries.find((e) => e.step.kind === "batchGroup");
+    expect(bgEntry).toBeDefined();
+    expect(bgEntry!.step.runResult).toBeUndefined();
+  });
+
+  it("getGenerationState should report not-latest when batchGroup covers many messages", async () => {
+    // getGenerationState uses journalEntries.length vs bufferSize to determine
+    // if we're "caught up". But a batchGroup entry covers N messages while
+    // taking only 1 slot in journalEntries.
+    //
+    // With 2 journal entries (1 batchGroup of 100 + 1 regular) and 5 buffered
+    // messages, the code thinks we're caught up (2 <= 5) but we actually need
+    // to process 101 messages before we're done replaying.
+    const bgEntry = fakeBatchGroupEntry(0, 100);
+    const regularEntry: JournalEntry = {
+      _id: "step_1",
+      _creationTime: Date.now(),
+      workflowId: "wf_test" as any,
+      stepNumber: 1,
+      step: {
+        kind: "function" as const,
+        functionType: "action" as const,
+        handle: "function://test",
+        name: "afterBatch",
+        inProgress: false,
+        argsSize: 2,
+        args: {},
+        runResult: { kind: "success" as const, returnValue: "done" },
+        startedAt: 1000,
+        completedAt: 2000,
+      },
+    };
+
+    const { executor, channel } = createExecutor({
+      journalEntries: [bgEntry, regularEntry],
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await channel.push(actionMessage(`s${i}`, "module:action"));
+    }
+
+    const state = executor.getGenerationState();
+    // BUG: returns latest=true because journalEntries.length (2) <= bufferSize (5)
+    // but we actually have 101 messages to replay. Should be latest=false.
+    expect(state.latest).toBe(false);
+  });
+
+  it("replay should give clear error when batchResults count < expected count", async () => {
+    // If loadBatchResults returns fewer results than entry.step.count,
+    // the code crashes with:
+    //   TypeError: Cannot read properties of undefined (reading 'result')
+    // It should throw a clear assertion error instead.
+    const bgEntry = fakeBatchGroupEntry(0, 3);
+    const { executor, channel, setMockBatchResults } = createExecutor({
+      journalEntries: [bgEntry],
+    });
+
+    // Only 2 results for count=3
+    setMockBatchResults([
+      { index: 0, result: { kind: "success", returnValue: "zero" } },
+      { index: 1, result: { kind: "success", returnValue: "one" } },
+    ]);
+
+    const msg0 = actionMessage("s0", "module:action");
+    const msg1 = actionMessage("s1", "module:action");
+    const msg2 = actionMessage("s2", "module:action");
+    const msgBlock = actionMessage("block", "module:action");
+    await channel.push(msg0);
+    await channel.push(msg1);
+    await channel.push(msg2);
+    await channel.push(msgBlock);
+
+    // Should throw a clear error about missing batch results, NOT a TypeError
+    await expect(executor.run()).rejects.toThrow(/batch.*result|missing|count/i);
+  });
+
+  it("replay should validate results count matches batchGroup count", async () => {
+    // Extra results (4 results for count=2) indicates data corruption.
+    // The code should detect this, not silently ignore the extras.
+    const bgEntry = fakeBatchGroupEntry(0, 2);
+    const { executor, channel, setMockBatchResults } = createExecutor({
+      journalEntries: [bgEntry],
+    });
+
+    setMockBatchResults([
+      { index: 0, result: { kind: "success", returnValue: "zero" } },
+      { index: 1, result: { kind: "success", returnValue: "one" } },
+      { index: 2, result: { kind: "success", returnValue: "extra1" } },
+      { index: 3, result: { kind: "success", returnValue: "extra2" } },
+    ]);
+
+    const msg0 = actionMessage("s0", "module:action");
+    const msg1 = actionMessage("s1", "module:action");
+    const msgBlock = actionMessage("block", "module:action");
+    await channel.push(msg0);
+    await channel.push(msg1);
+    await channel.push(msgBlock);
+
+    // Should throw on count mismatch (4 results for 2 expected)
+    await expect(executor.run()).rejects.toThrow();
+  });
+
+  it("replay should validate result indices are contiguous 0..N-1", async () => {
+    // Results with non-contiguous indices (gap: 0, 2, 4 for count=3) means
+    // sort-by-index then access-by-position gives wrong results:
+    // results[1] = {index:2, ...} instead of {index:1, ...}.
+    const bgEntry = fakeBatchGroupEntry(0, 3);
+    const { executor, channel, setMockBatchResults } = createExecutor({
+      journalEntries: [bgEntry],
+    });
+
+    setMockBatchResults([
+      { index: 0, result: { kind: "success", returnValue: "zero" } },
+      { index: 2, result: { kind: "success", returnValue: "two" } },
+      { index: 4, result: { kind: "success", returnValue: "four" } },
+    ]);
+
+    const msg0 = actionMessage("s0", "module:action");
+    const msg1 = actionMessage("s1", "module:action");
+    const msg2 = actionMessage("s2", "module:action");
+    const msgBlock = actionMessage("block", "module:action");
+    await channel.push(msg0);
+    await channel.push(msg1);
+    await channel.push(msg2);
+    await channel.push(msgBlock);
+
+    // Should throw because indices [0,2,4] are not contiguous [0,1,2].
+    // Current bug: silently assigns msg1 the result for index 2.
+    await expect(executor.run()).rejects.toThrow(/index|contiguous|mismatch/i);
+  });
+});

--- a/src/client/step.test.ts
+++ b/src/client/step.test.ts
@@ -66,7 +66,7 @@ function mutationMessage(
   };
 }
 
-// Helper to create a fake journal entry
+// Helper to create a fake journal entry (function kind)
 function fakeEntry(stepNumber: number, name: string): JournalEntry {
   return {
     _id: `step_${stepNumber}`,
@@ -88,6 +88,34 @@ function fakeEntry(stepNumber: number, name: string): JournalEntry {
   };
 }
 
+// Helper to create a fake batchGroup journal entry
+function fakeBatchGroupEntry(
+  stepNumber: number,
+  count: number,
+  opts?: { inProgress?: boolean },
+): JournalEntry {
+  return {
+    _id: `step_bg_${stepNumber}`,
+    _creationTime: Date.now(),
+    workflowId: "wf_test" as any,
+    stepNumber,
+    step: {
+      kind: "batchGroup" as const,
+      count,
+      name: "batchGroup",
+      inProgress: opts?.inProgress ?? false,
+      argsSize: 0,
+      args: {},
+      runResult:
+        opts?.inProgress === true
+          ? undefined
+          : { kind: "success" as const, returnValue: null },
+      startedAt: Date.now(),
+      completedAt: opts?.inProgress === true ? undefined : Date.now(),
+    },
+  };
+}
+
 function createMockBatch(registeredNames: string[]) {
   return {
     isRegistered: vi.fn((name: string) => registeredNames.includes(name)),
@@ -95,67 +123,98 @@ function createMockBatch(registeredNames: string[]) {
       registeredNames.includes(name) ? `handler:${name}` : null,
     ),
     enqueueByHandle: vi.fn(async () => {}),
+    options: { maxWorkers: 2 },
+    component: {
+      batch: {
+        enqueueBatch: { __type: "enqueueBatch" } as any,
+      },
+    },
   } as unknown as BatchWorkpool;
 }
 
-function createExecutor(batch?: BatchWorkpool) {
-  // Track which mutations are called and in what order
-  const callLog: Array<{ mutation: string; names: string[] }> = [];
+function createExecutor(
+  opts?: {
+    batch?: BatchWorkpool;
+    journalEntries?: JournalEntry[];
+  },
+) {
+  const batch = opts?.batch;
+  const journalEntries = opts?.journalEntries ?? [];
+
+  // Track which mutations/queries are called and in what order
+  const callLog: Array<{ mutation: string; names?: string[]; count?: number }> =
+    [];
 
   let stepCounter = 0;
-  const mockCtx = {
-    runMutation: vi.fn(async (_ref: any, args: any) => {
-      const mutationName =
-        _ref === mockComponent.journal.startSteps
-          ? "startSteps"
-          : _ref === mockComponent.journal.startBatchSteps
-            ? "startBatchSteps"
-            : "unknown";
-      const names = args.steps.map((s: any) => s.step.name);
-      callLog.push({ mutation: mutationName, names });
-
-      const entries = args.steps.map((s: any) => {
-        const entry = fakeEntry(stepCounter, s.step.name);
-        stepCounter++;
-        return entry;
-      });
-
-      if (mutationName === "startBatchSteps") {
-        return { entries, onCompleteHandle: "function://onComplete" };
-      }
-      return entries;
-    }),
-  } as any;
-
   const mockComponent = {
     journal: {
       startSteps: { __type: "startSteps" } as any,
       startBatchSteps: { __type: "startBatchSteps" } as any,
+      startBatchGroupStep: { __type: "startBatchGroupStep" } as any,
+      loadBatchResults: { __type: "loadBatchResults" } as any,
     },
   } as any;
 
-  // Patch the mock to use the component refs
-  mockCtx.runMutation.mockImplementation(async (_ref: any, args: any) => {
-    const mutationName =
-      _ref === mockComponent.journal.startSteps
-        ? "startSteps"
-        : _ref === mockComponent.journal.startBatchSteps
-          ? "startBatchSteps"
-          : "unknown";
-    const names = args.steps.map((s: any) => s.step.name);
-    callLog.push({ mutation: mutationName, names });
+  // Mock batch results that can be pre-loaded for replay tests
+  let mockBatchResults: Array<{
+    index: number;
+    result: { kind: string; returnValue?: unknown; error?: string };
+  }> = [];
 
-    const entries = args.steps.map((s: any) => {
-      const entry = fakeEntry(stepCounter, s.step.name);
-      stepCounter++;
-      return entry;
-    });
+  const batchEnqueueRef = batch
+    ? (batch as any).component.batch.enqueueBatch
+    : null;
 
-    if (mutationName === "startBatchSteps") {
-      return { entries, onCompleteHandle: "function://onComplete" };
-    }
-    return entries;
-  });
+  const mockCtx = {
+    runMutation: vi.fn(async (_ref: any, args: any) => {
+      if (batchEnqueueRef && _ref === batchEnqueueRef) {
+        callLog.push({
+          mutation: "batchEnqueueBatch",
+          names: args.tasks.map((t: any) => t.name),
+        });
+        return args.tasks.map(() => "task_id");
+      }
+      if (_ref === mockComponent.journal.startBatchGroupStep) {
+        const entry = fakeBatchGroupEntry(stepCounter, args.count, {
+          inProgress: true,
+        });
+        stepCounter++;
+        callLog.push({
+          mutation: "startBatchGroupStep",
+          count: args.count,
+        });
+        return { entry, onCompleteHandle: "function://onComplete" };
+      }
+      if (_ref === mockComponent.journal.startBatchSteps) {
+        const names = args.steps.map((s: any) => s.step.name);
+        callLog.push({ mutation: "startBatchSteps", names });
+        const entries = args.steps.map((s: any) => {
+          const entry = fakeEntry(stepCounter, s.step.name);
+          stepCounter++;
+          return entry;
+        });
+        return { entries, onCompleteHandle: "function://onComplete" };
+      }
+      if (_ref === mockComponent.journal.startSteps) {
+        const names = args.steps.map((s: any) => s.step.name);
+        callLog.push({ mutation: "startSteps", names });
+        const entries = args.steps.map((s: any) => {
+          const entry = fakeEntry(stepCounter, s.step.name);
+          stepCounter++;
+          return entry;
+        });
+        return entries;
+      }
+      callLog.push({ mutation: "unknown" });
+      return null;
+    }),
+    runQuery: vi.fn(async (_ref: any, _args: any) => {
+      if (_ref === mockComponent.journal.loadBatchResults) {
+        return mockBatchResults;
+      }
+      return [];
+    }),
+  } as any;
 
   const channel = new BaseChannel<StepRequest>(100);
   const executor = new StepExecutor(
@@ -163,14 +222,27 @@ function createExecutor(batch?: BatchWorkpool) {
     1,
     mockCtx,
     mockComponent,
-    [],
+    journalEntries,
     channel,
     Date.now(),
     undefined,
     batch,
   );
 
-  return { executor, callLog, mockCtx };
+  return {
+    executor,
+    callLog,
+    mockCtx,
+    channel,
+    setMockBatchResults(
+      results: Array<{
+        index: number;
+        result: { kind: string; returnValue?: unknown; error?: string };
+      }>,
+    ) {
+      mockBatchResults = results;
+    },
+  };
 }
 
 describe("StepExecutor.startSteps", () => {
@@ -192,7 +264,7 @@ describe("StepExecutor.startSteps", () => {
 
   it("routes all messages through regular when none are batch-registered", async () => {
     const batch = createMockBatch([]); // nothing registered
-    const { executor, callLog } = createExecutor(batch);
+    const { executor, callLog } = createExecutor({ batch });
 
     const messages = [
       actionMessage("step1", "module:action1"),
@@ -206,9 +278,9 @@ describe("StepExecutor.startSteps", () => {
     expect(entries).toHaveLength(2);
   });
 
-  it("routes all batch-eligible messages through batch", async () => {
+  it("routes all batch-eligible messages through batchGroup", async () => {
     const batch = createMockBatch(["module:batchAction"]);
-    const { executor, callLog } = createExecutor(batch);
+    const { executor, callLog } = createExecutor({ batch });
 
     const messages = [
       actionMessage("step1", "module:batchAction", { a: 1 }),
@@ -217,15 +289,20 @@ describe("StepExecutor.startSteps", () => {
 
     const entries = await executor.startSteps(messages);
 
-    expect(callLog).toHaveLength(1);
-    expect(callLog[0].mutation).toBe("startBatchSteps");
-    expect(callLog[0].names).toEqual(["step1", "step2"]);
-    expect(entries).toHaveLength(2);
+    // startBatchGroupStep creates 1 journal entry, then enqueueByHandle (1st,
+    // not logged) + batchEnqueueBatch (rest) enqueue the tasks.
+    expect(callLog).toHaveLength(2);
+    expect(callLog[0].mutation).toBe("startBatchGroupStep");
+    expect(callLog[0].count).toBe(2);
+    expect(callLog[1].mutation).toBe("batchEnqueueBatch");
+    expect(callLog[1].names).toEqual(["handler:module:batchAction"]);
+    // Only 1 entry returned (the batchGroup step)
+    expect(entries).toHaveLength(1);
   });
 
   it("preserves original message order for interleaved batch/regular steps", async () => {
     const batch = createMockBatch(["module:batchAction"]);
-    const { executor, callLog } = createExecutor(batch);
+    const { executor, callLog } = createExecutor({ batch });
 
     // Interleaved: batch, regular, batch
     const messages = [
@@ -236,33 +313,33 @@ describe("StepExecutor.startSteps", () => {
 
     const entries = await executor.startSteps(messages);
 
-    // Should process 3 contiguous groups in order
+    // 3 groups: batchGroup(1 item) -> startSteps(1 item) -> batchGroup(1 item)
     expect(callLog).toHaveLength(3);
-    expect(callLog[0]).toEqual({
-      mutation: "startBatchSteps",
-      names: ["batch1"],
+    expect(callLog[0]).toMatchObject({
+      mutation: "startBatchGroupStep",
+      count: 1,
     });
     expect(callLog[1]).toEqual({
       mutation: "startSteps",
       names: ["regular1"],
     });
-    expect(callLog[2]).toEqual({
-      mutation: "startBatchSteps",
-      names: ["batch2"],
+    expect(callLog[2]).toMatchObject({
+      mutation: "startBatchGroupStep",
+      count: 1,
     });
 
-    // Step numbers should be in original message order
-    expect(entries.map((e) => e.step.name)).toEqual([
-      "batch1",
-      "regular1",
-      "batch2",
+    // Entries: batchGroup entry, regular entry, batchGroup entry
+    expect(entries).toHaveLength(3);
+    expect(entries.map((e) => e.step.kind)).toEqual([
+      "batchGroup",
+      "function",
+      "batchGroup",
     ]);
-    expect(entries.map((e) => e.stepNumber)).toEqual([0, 1, 2]);
   });
 
   it("handles contiguous groups correctly", async () => {
     const batch = createMockBatch(["module:batchAction"]);
-    const { executor, callLog } = createExecutor(batch);
+    const { executor, callLog } = createExecutor({ batch });
 
     // Two batch, two regular, one batch
     const messages = [
@@ -275,33 +352,34 @@ describe("StepExecutor.startSteps", () => {
 
     const entries = await executor.startSteps(messages);
 
-    expect(callLog).toHaveLength(3);
-    expect(callLog[0]).toEqual({
-      mutation: "startBatchSteps",
-      names: ["b1", "b2"],
+    // First batch group: startBatchGroupStep(count=2) + batchEnqueueBatch(1 remaining)
+    // Regular group: startSteps
+    // Second batch group: startBatchGroupStep(count=1)
+    expect(callLog).toHaveLength(4);
+    expect(callLog[0]).toMatchObject({
+      mutation: "startBatchGroupStep",
+      count: 2,
     });
     expect(callLog[1]).toEqual({
+      mutation: "batchEnqueueBatch",
+      names: ["handler:module:batchAction"],
+    });
+    expect(callLog[2]).toEqual({
       mutation: "startSteps",
       names: ["r1", "r2"],
     });
-    expect(callLog[2]).toEqual({
-      mutation: "startBatchSteps",
-      names: ["b3"],
+    expect(callLog[3]).toMatchObject({
+      mutation: "startBatchGroupStep",
+      count: 1,
     });
 
-    expect(entries.map((e) => e.step.name)).toEqual([
-      "b1",
-      "b2",
-      "r1",
-      "r2",
-      "b3",
-    ]);
-    expect(entries.map((e) => e.stepNumber)).toEqual([0, 1, 2, 3, 4]);
+    // 1 batchGroup + 2 regular + 1 batchGroup = 4 entries
+    expect(entries).toHaveLength(4);
   });
 
   it("mutations are never batch-eligible even with batch configured", async () => {
     const batch = createMockBatch(["module:batchAction"]);
-    const { executor, callLog } = createExecutor(batch);
+    const { executor, callLog } = createExecutor({ batch });
 
     const messages = [
       mutationMessage("mut1", "module:myMutation"),
@@ -317,7 +395,7 @@ describe("StepExecutor.startSteps", () => {
 
   it("unregistered actions go through regular workpool", async () => {
     const batch = createMockBatch(["module:batchAction"]);
-    const { executor, callLog } = createExecutor(batch);
+    const { executor, callLog } = createExecutor({ batch });
 
     const messages = [
       actionMessage("step1", "module:nonBatchAction"),
@@ -332,10 +410,149 @@ describe("StepExecutor.startSteps", () => {
       mutation: "startSteps",
       names: ["step1"],
     });
-    expect(callLog[1]).toEqual({
-      mutation: "startBatchSteps",
-      names: ["step2"],
+    expect(callLog[1]).toMatchObject({
+      mutation: "startBatchGroupStep",
+      count: 1,
     });
-    expect(entries.map((e) => e.stepNumber)).toEqual([0, 1]);
+    // 1 regular entry + 1 batchGroup entry = 2
+    expect(entries).toHaveLength(2);
+  });
+});
+
+describe("StepExecutor.run batchGroup replay", () => {
+  it("replays a completed batchGroup entry resolving N messages", async () => {
+    // Pre-load a completed batchGroup entry for 3 items
+    const bgEntry = fakeBatchGroupEntry(0, 3);
+    const { executor, channel, setMockBatchResults } = createExecutor({
+      journalEntries: [bgEntry],
+    });
+
+    // Pre-load batch results
+    setMockBatchResults([
+      { index: 0, result: { kind: "success", returnValue: "result0" } },
+      { index: 1, result: { kind: "success", returnValue: "result1" } },
+      { index: 2, result: { kind: "success", returnValue: "result2" } },
+    ]);
+
+    // Send 3 messages that will be replayed from the batchGroup entry.
+    // We need a 4th message to trigger executorBlocked (since after replay,
+    // the loop continues and picks up the next message).
+    const msg0 = actionMessage("s0", "module:action");
+    const msg1 = actionMessage("s1", "module:action");
+    const msg2 = actionMessage("s2", "module:action");
+    const msgBlock = actionMessage("sBlock", "module:action");
+
+    // Put msg1 and msg2 in buffer first (msg0 will be consumed by get())
+    await channel.push(msg0);
+    await channel.push(msg1);
+    await channel.push(msg2);
+    await channel.push(msgBlock);
+
+    const result = await executor.run();
+
+    expect(result.type).toBe("executorBlocked");
+    expect(msg0.resolve).toHaveBeenCalledWith("result0");
+    expect(msg1.resolve).toHaveBeenCalledWith("result1");
+    expect(msg2.resolve).toHaveBeenCalledWith("result2");
+  });
+
+  it("replays mixed regular + batchGroup entries", async () => {
+    // Pre-load: regular entry, batchGroup(2), regular entry
+    const regularEntry0: JournalEntry = {
+      _id: "step_0",
+      _creationTime: Date.now(),
+      workflowId: "wf_test" as any,
+      stepNumber: 0,
+      step: {
+        kind: "function" as const,
+        functionType: "action" as const,
+        handle: "function://test",
+        name: "regular0",
+        inProgress: false,
+        argsSize: 2,
+        args: {},
+        runResult: { kind: "success" as const, returnValue: "r0" },
+        startedAt: Date.now(),
+        completedAt: Date.now(),
+      },
+    };
+    const bgEntry = fakeBatchGroupEntry(1, 2);
+    const regularEntry2: JournalEntry = {
+      _id: "step_2",
+      _creationTime: Date.now(),
+      workflowId: "wf_test" as any,
+      stepNumber: 2,
+      step: {
+        kind: "function" as const,
+        functionType: "action" as const,
+        handle: "function://test",
+        name: "regular2",
+        inProgress: false,
+        argsSize: 2,
+        args: {},
+        runResult: { kind: "success" as const, returnValue: "r2" },
+        startedAt: Date.now(),
+        completedAt: Date.now(),
+      },
+    };
+
+    const { executor, channel, setMockBatchResults } = createExecutor({
+      journalEntries: [regularEntry0, bgEntry, regularEntry2],
+    });
+
+    setMockBatchResults([
+      { index: 0, result: { kind: "success", returnValue: "batch0" } },
+      { index: 1, result: { kind: "success", returnValue: "batch1" } },
+    ]);
+
+    const msg0 = actionMessage("regular0", "module:action", {});
+    const msgBatch0 = actionMessage("batchStep0", "module:action");
+    const msgBatch1 = actionMessage("batchStep1", "module:action");
+    const msg2 = actionMessage("regular2", "module:action", {});
+    const msgBlock = actionMessage("block", "module:action");
+
+    await channel.push(msg0);
+    await channel.push(msgBatch0);
+    await channel.push(msgBatch1);
+    await channel.push(msg2);
+    await channel.push(msgBlock);
+
+    const result = await executor.run();
+
+    expect(result.type).toBe("executorBlocked");
+    expect(msg0.resolve).toHaveBeenCalledWith("r0");
+    expect(msgBatch0.resolve).toHaveBeenCalledWith("batch0");
+    expect(msgBatch1.resolve).toHaveBeenCalledWith("batch1");
+    expect(msg2.resolve).toHaveBeenCalledWith("r2");
+  });
+
+  it("handles partial failures in batchGroup results", async () => {
+    const bgEntry = fakeBatchGroupEntry(0, 3);
+    const { executor, channel, setMockBatchResults } = createExecutor({
+      journalEntries: [bgEntry],
+    });
+
+    setMockBatchResults([
+      { index: 0, result: { kind: "success", returnValue: "ok" } },
+      { index: 1, result: { kind: "failed", error: "item 1 failed" } },
+      { index: 2, result: { kind: "canceled" } },
+    ]);
+
+    const msg0 = actionMessage("s0", "module:action");
+    const msg1 = actionMessage("s1", "module:action");
+    const msg2 = actionMessage("s2", "module:action");
+    const msgBlock = actionMessage("sBlock", "module:action");
+
+    await channel.push(msg0);
+    await channel.push(msg1);
+    await channel.push(msg2);
+    await channel.push(msgBlock);
+
+    const result = await executor.run();
+
+    expect(result.type).toBe("executorBlocked");
+    expect(msg0.resolve).toHaveBeenCalledWith("ok");
+    expect(msg1.reject).toHaveBeenCalledWith(new Error("item 1 failed"));
+    expect(msg2.reject).toHaveBeenCalledWith(new Error("Canceled"));
   });
 });

--- a/src/client/step.test.ts
+++ b/src/client/step.test.ts
@@ -1,0 +1,341 @@
+/// <reference types="vite/client" />
+
+import { describe, it, expect, vi } from "vitest";
+import { BaseChannel } from "async-channel";
+import { StepExecutor, type StepRequest } from "./step.js";
+import type { JournalEntry } from "../component/schema.js";
+import type { BatchWorkpool } from "@convex-dev/workpool";
+import { makeFunctionReference } from "convex/server";
+
+// Mock createFunctionHandle to avoid needing a real Convex backend
+vi.mock("convex/server", async (importOriginal) => {
+  const mod = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...mod,
+    createFunctionHandle: vi.fn(async (ref: any) => {
+      const addr = mod.getFunctionAddress as (ref: any) => any;
+      return `function://${addr(ref).name ?? "unknown"}`;
+    }),
+  };
+});
+
+// Helper to create a mock function reference
+function mockFnRef(name: string) {
+  return makeFunctionReference(name) as any;
+}
+
+// Helper to create a StepRequest for an action
+function actionMessage(
+  name: string,
+  fnName: string,
+  args: Record<string, unknown> = {},
+): StepRequest {
+  return {
+    name,
+    target: {
+      kind: "function",
+      functionType: "action",
+      function: mockFnRef(fnName),
+      args,
+    },
+    retry: undefined,
+    schedulerOptions: {},
+    resolve: vi.fn(),
+    reject: vi.fn(),
+  };
+}
+
+// Helper to create a StepRequest for a mutation (non-batch-eligible)
+function mutationMessage(
+  name: string,
+  fnName: string,
+  args: Record<string, unknown> = {},
+): StepRequest {
+  return {
+    name,
+    target: {
+      kind: "function",
+      functionType: "mutation",
+      function: mockFnRef(fnName),
+      args,
+    },
+    retry: undefined,
+    schedulerOptions: {},
+    resolve: vi.fn(),
+    reject: vi.fn(),
+  };
+}
+
+// Helper to create a fake journal entry
+function fakeEntry(stepNumber: number, name: string): JournalEntry {
+  return {
+    _id: `step_${stepNumber}`,
+    _creationTime: Date.now(),
+    workflowId: "wf_test" as any,
+    stepNumber,
+    step: {
+      kind: "function" as const,
+      functionType: "action" as const,
+      handle: "function://test",
+      name,
+      inProgress: true,
+      argsSize: 2,
+      args: {},
+      runResult: undefined,
+      startedAt: Date.now(),
+      completedAt: undefined,
+    },
+  };
+}
+
+function createMockBatch(registeredNames: string[]) {
+  return {
+    isRegistered: vi.fn((name: string) => registeredNames.includes(name)),
+    resolveHandlerName: vi.fn((name: string) =>
+      registeredNames.includes(name) ? `handler:${name}` : null,
+    ),
+    enqueueByHandle: vi.fn(async () => {}),
+  } as unknown as BatchWorkpool;
+}
+
+function createExecutor(batch?: BatchWorkpool) {
+  // Track which mutations are called and in what order
+  const callLog: Array<{ mutation: string; names: string[] }> = [];
+
+  let stepCounter = 0;
+  const mockCtx = {
+    runMutation: vi.fn(async (_ref: any, args: any) => {
+      const mutationName =
+        _ref === mockComponent.journal.startSteps
+          ? "startSteps"
+          : _ref === mockComponent.journal.startBatchSteps
+            ? "startBatchSteps"
+            : "unknown";
+      const names = args.steps.map((s: any) => s.step.name);
+      callLog.push({ mutation: mutationName, names });
+
+      const entries = args.steps.map((s: any) => {
+        const entry = fakeEntry(stepCounter, s.step.name);
+        stepCounter++;
+        return entry;
+      });
+
+      if (mutationName === "startBatchSteps") {
+        return { entries, onCompleteHandle: "function://onComplete" };
+      }
+      return entries;
+    }),
+  } as any;
+
+  const mockComponent = {
+    journal: {
+      startSteps: { __type: "startSteps" } as any,
+      startBatchSteps: { __type: "startBatchSteps" } as any,
+    },
+  } as any;
+
+  // Patch the mock to use the component refs
+  mockCtx.runMutation.mockImplementation(async (_ref: any, args: any) => {
+    const mutationName =
+      _ref === mockComponent.journal.startSteps
+        ? "startSteps"
+        : _ref === mockComponent.journal.startBatchSteps
+          ? "startBatchSteps"
+          : "unknown";
+    const names = args.steps.map((s: any) => s.step.name);
+    callLog.push({ mutation: mutationName, names });
+
+    const entries = args.steps.map((s: any) => {
+      const entry = fakeEntry(stepCounter, s.step.name);
+      stepCounter++;
+      return entry;
+    });
+
+    if (mutationName === "startBatchSteps") {
+      return { entries, onCompleteHandle: "function://onComplete" };
+    }
+    return entries;
+  });
+
+  const channel = new BaseChannel<StepRequest>(100);
+  const executor = new StepExecutor(
+    "wf_test",
+    1,
+    mockCtx,
+    mockComponent,
+    [],
+    channel,
+    Date.now(),
+    undefined,
+    batch,
+  );
+
+  return { executor, callLog, mockCtx };
+}
+
+describe("StepExecutor.startSteps", () => {
+  it("routes all messages through regular when no batch is configured", async () => {
+    const { executor, callLog } = createExecutor();
+
+    const messages = [
+      actionMessage("step1", "module:action1"),
+      actionMessage("step2", "module:action2"),
+    ];
+
+    const entries = await executor.startSteps(messages);
+
+    expect(callLog).toHaveLength(1);
+    expect(callLog[0].mutation).toBe("startSteps");
+    expect(callLog[0].names).toEqual(["step1", "step2"]);
+    expect(entries).toHaveLength(2);
+  });
+
+  it("routes all messages through regular when none are batch-registered", async () => {
+    const batch = createMockBatch([]); // nothing registered
+    const { executor, callLog } = createExecutor(batch);
+
+    const messages = [
+      actionMessage("step1", "module:action1"),
+      actionMessage("step2", "module:action2"),
+    ];
+
+    const entries = await executor.startSteps(messages);
+
+    expect(callLog).toHaveLength(1);
+    expect(callLog[0].mutation).toBe("startSteps");
+    expect(entries).toHaveLength(2);
+  });
+
+  it("routes all batch-eligible messages through batch", async () => {
+    const batch = createMockBatch(["module:batchAction"]);
+    const { executor, callLog } = createExecutor(batch);
+
+    const messages = [
+      actionMessage("step1", "module:batchAction", { a: 1 }),
+      actionMessage("step2", "module:batchAction", { a: 2 }),
+    ];
+
+    const entries = await executor.startSteps(messages);
+
+    expect(callLog).toHaveLength(1);
+    expect(callLog[0].mutation).toBe("startBatchSteps");
+    expect(callLog[0].names).toEqual(["step1", "step2"]);
+    expect(entries).toHaveLength(2);
+  });
+
+  it("preserves original message order for interleaved batch/regular steps", async () => {
+    const batch = createMockBatch(["module:batchAction"]);
+    const { executor, callLog } = createExecutor(batch);
+
+    // Interleaved: batch, regular, batch
+    const messages = [
+      actionMessage("batch1", "module:batchAction"),
+      mutationMessage("regular1", "module:myMutation"),
+      actionMessage("batch2", "module:batchAction"),
+    ];
+
+    const entries = await executor.startSteps(messages);
+
+    // Should process 3 contiguous groups in order
+    expect(callLog).toHaveLength(3);
+    expect(callLog[0]).toEqual({
+      mutation: "startBatchSteps",
+      names: ["batch1"],
+    });
+    expect(callLog[1]).toEqual({
+      mutation: "startSteps",
+      names: ["regular1"],
+    });
+    expect(callLog[2]).toEqual({
+      mutation: "startBatchSteps",
+      names: ["batch2"],
+    });
+
+    // Step numbers should be in original message order
+    expect(entries.map((e) => e.step.name)).toEqual([
+      "batch1",
+      "regular1",
+      "batch2",
+    ]);
+    expect(entries.map((e) => e.stepNumber)).toEqual([0, 1, 2]);
+  });
+
+  it("handles contiguous groups correctly", async () => {
+    const batch = createMockBatch(["module:batchAction"]);
+    const { executor, callLog } = createExecutor(batch);
+
+    // Two batch, two regular, one batch
+    const messages = [
+      actionMessage("b1", "module:batchAction"),
+      actionMessage("b2", "module:batchAction"),
+      mutationMessage("r1", "module:myMutation"),
+      mutationMessage("r2", "module:myMutation"),
+      actionMessage("b3", "module:batchAction"),
+    ];
+
+    const entries = await executor.startSteps(messages);
+
+    expect(callLog).toHaveLength(3);
+    expect(callLog[0]).toEqual({
+      mutation: "startBatchSteps",
+      names: ["b1", "b2"],
+    });
+    expect(callLog[1]).toEqual({
+      mutation: "startSteps",
+      names: ["r1", "r2"],
+    });
+    expect(callLog[2]).toEqual({
+      mutation: "startBatchSteps",
+      names: ["b3"],
+    });
+
+    expect(entries.map((e) => e.step.name)).toEqual([
+      "b1",
+      "b2",
+      "r1",
+      "r2",
+      "b3",
+    ]);
+    expect(entries.map((e) => e.stepNumber)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("mutations are never batch-eligible even with batch configured", async () => {
+    const batch = createMockBatch(["module:batchAction"]);
+    const { executor, callLog } = createExecutor(batch);
+
+    const messages = [
+      mutationMessage("mut1", "module:myMutation"),
+      mutationMessage("mut2", "module:myMutation"),
+    ];
+
+    const entries = await executor.startSteps(messages);
+
+    expect(callLog).toHaveLength(1);
+    expect(callLog[0].mutation).toBe("startSteps");
+    expect(entries).toHaveLength(2);
+  });
+
+  it("unregistered actions go through regular workpool", async () => {
+    const batch = createMockBatch(["module:batchAction"]);
+    const { executor, callLog } = createExecutor(batch);
+
+    const messages = [
+      actionMessage("step1", "module:nonBatchAction"),
+      actionMessage("step2", "module:batchAction"),
+    ];
+
+    const entries = await executor.startSteps(messages);
+
+    // nonBatchAction is regular, batchAction is batch
+    expect(callLog).toHaveLength(2);
+    expect(callLog[0]).toEqual({
+      mutation: "startSteps",
+      names: ["step1"],
+    });
+    expect(callLog[1]).toEqual({
+      mutation: "startBatchSteps",
+      names: ["step2"],
+    });
+    expect(entries.map((e) => e.stepNumber)).toEqual([0, 1]);
+  });
+});

--- a/src/client/step.ts
+++ b/src/client/step.ts
@@ -1,4 +1,5 @@
 import type {
+  BatchWorkpool,
   RetryBehavior,
   RunResult,
   WorkpoolOptions,
@@ -22,6 +23,7 @@ import {
 import type { WorkflowComponent } from "./types.js";
 import { MAX_JOURNAL_SIZE } from "../shared.js";
 import type { EventId, SchedulerOptions } from "../types.js";
+import { safeFunctionName } from "./safeFunctionName.js";
 
 export type WorkerResult =
   | { type: "handlerDone"; runResult: RunResult }
@@ -64,6 +66,7 @@ export class StepExecutor {
     private receiver: BaseChannel<StepRequest>,
     private now: number,
     private workpoolOptions: WorkpoolOptions | undefined,
+    private batch?: BatchWorkpool,
   ) {
     this.journalEntrySize = journalEntries.reduce(
       (size, entry) => size + journalEntrySize(entry),
@@ -154,38 +157,64 @@ export class StepExecutor {
   }
 
   async startSteps(messages: StepRequest[]): Promise<JournalEntry[]> {
+    if (!this.batch) {
+      return this._startStepsRegular(messages);
+    }
+
+    // Split messages into batch-eligible and regular
+    const batchIndices: number[] = [];
+    const regularIndices: number[] = [];
+    for (let i = 0; i < messages.length; i++) {
+      const target = messages[i].target;
+      if (
+        target.kind === "function" &&
+        target.functionType === "action" &&
+        this.batch.isRegistered(safeFunctionName(target.function))
+      ) {
+        batchIndices.push(i);
+      } else {
+        regularIndices.push(i);
+      }
+    }
+
+    if (batchIndices.length === 0) {
+      return this._startStepsRegular(messages);
+    }
+
+    // Process sequentially to avoid step number collisions.
+    // Batch messages first, then regular.
+    const allEntries: Array<{ index: number; entry: JournalEntry }> = [];
+
+    if (batchIndices.length > 0) {
+      const batchMessages = batchIndices.map((i) => messages[i]);
+      const batchEntries = await this._startStepsBatch(batchMessages);
+      for (let i = 0; i < batchIndices.length; i++) {
+        allEntries.push({ index: batchIndices[i], entry: batchEntries[i] });
+      }
+    }
+
+    if (regularIndices.length > 0) {
+      const regularMessages = regularIndices.map((i) => messages[i]);
+      const regularEntries = await this._startStepsRegular(regularMessages);
+      for (let i = 0; i < regularIndices.length; i++) {
+        allEntries.push({
+          index: regularIndices[i],
+          entry: regularEntries[i],
+        });
+      }
+    }
+
+    // Merge back in original message order
+    allEntries.sort((a, b) => a.index - b.index);
+    return allEntries.map((e) => e.entry);
+  }
+
+  private async _startStepsRegular(
+    messages: StepRequest[],
+  ): Promise<JournalEntry[]> {
     const steps = await Promise.all(
       messages.map(async (message) => {
-        const commonFields = {
-          inProgress: true,
-          name: message.name,
-          args: message.target.args,
-          argsSize: valueSize(message.target.args as Value),
-          runResult: undefined,
-          startedAt: this.now,
-          completedAt: undefined,
-        } satisfies Omit<Step, "kind">;
-        const target = message.target;
-        const step =
-          target.kind === "function"
-            ? {
-                kind: "function" as const,
-                functionType: target.functionType,
-                handle: await createFunctionHandle(target.function),
-                ...commonFields,
-              }
-            : target.kind === "workflow"
-              ? {
-                  kind: "workflow" as const,
-                  handle: await createFunctionHandle(target.function),
-                  ...commonFields,
-                }
-              : {
-                  kind: "event" as const,
-                  eventId: target.args.eventId,
-                  ...commonFields,
-                  args: target.args,
-                };
+        const step = await this._buildStep(message);
         return {
           retry: message.retry,
           schedulerOptions: message.schedulerOptions,
@@ -202,6 +231,95 @@ export class StepExecutor {
         workpoolOptions: this.workpoolOptions,
       },
     )) as JournalEntry[];
+    this._checkJournalSize(entries);
+    return entries;
+  }
+
+  private async _startStepsBatch(
+    messages: StepRequest[],
+  ): Promise<JournalEntry[]> {
+    const steps = await Promise.all(
+      messages.map(async (message) => {
+        const step = await this._buildStep(message);
+        return {
+          retry: message.retry,
+          schedulerOptions: message.schedulerOptions,
+          step,
+        };
+      }),
+    );
+    const { entries, onCompleteHandle } = (await this.ctx.runMutation(
+      this.component.journal.startBatchSteps,
+      {
+        workflowId: this.workflowId,
+        generationNumber: this.generationNumber,
+        steps,
+        workpoolOptions: this.workpoolOptions,
+      },
+    )) as { entries: JournalEntry[]; onCompleteHandle: string };
+    this._checkJournalSize(entries);
+
+    // Enqueue each batch task with the onComplete handle
+    for (const entry of entries) {
+      const target = messages[entries.indexOf(entry)].target;
+      if (target.kind !== "function") continue;
+      const handlerName = this.batch!.resolveHandlerName(
+        safeFunctionName(target.function),
+      );
+      if (!handlerName) continue;
+      await this.batch!.enqueueByHandle(
+        this.ctx,
+        handlerName,
+        entry.step.args as Record<string, unknown>,
+        {
+          onComplete: {
+            fnHandle: onCompleteHandle,
+            context: {
+              stepId: entry._id,
+              generationNumber: this.generationNumber,
+              workpoolOptions: this.workpoolOptions,
+            },
+          },
+          retry: messages[entries.indexOf(entry)].retry,
+        },
+      );
+    }
+    return entries;
+  }
+
+  private async _buildStep(message: StepRequest) {
+    const commonFields = {
+      inProgress: true,
+      name: message.name,
+      args: message.target.args,
+      argsSize: valueSize(message.target.args as Value),
+      runResult: undefined,
+      startedAt: this.now,
+      completedAt: undefined,
+    } satisfies Omit<Step, "kind">;
+    const target = message.target;
+    return target.kind === "function"
+      ? {
+          kind: "function" as const,
+          functionType: target.functionType,
+          handle: await createFunctionHandle(target.function),
+          ...commonFields,
+        }
+      : target.kind === "workflow"
+        ? {
+            kind: "workflow" as const,
+            handle: await createFunctionHandle(target.function),
+            ...commonFields,
+          }
+        : {
+            kind: "event" as const,
+            eventId: target.args.eventId,
+            ...commonFields,
+            args: target.args,
+          };
+  }
+
+  private _checkJournalSize(entries: JournalEntry[]) {
     for (const entry of entries) {
       this.journalEntrySize += journalEntrySize(entry);
       if (this.journalEntrySize > MAX_JOURNAL_SIZE) {
@@ -211,7 +329,6 @@ export class StepExecutor {
         );
       }
     }
-    return entries;
   }
 }
 

--- a/src/client/step.ts
+++ b/src/client/step.ts
@@ -83,9 +83,40 @@ export class StepExecutor {
       const message = await this.receiver.get();
       // In the future we can correlate the calls to entries by handle, args,
       // etc. instead of just ordering. As is, the fn order can't change.
-      const entry = this.journalEntries.shift();
-      // why not to run queries inline: they fetch too much data internally
+      const entry = this.journalEntries[0];
+
+      // Handle batchGroup replay: one entry covers N messages.
+      if (entry && entry.step.kind === "batchGroup") {
+        this.journalEntries.shift();
+        if (entry.step.inProgress) {
+          throw new Error(
+            `Assertion failed: batchGroup entry still in progress`,
+          );
+        }
+        // Load all individual results from the batchResults table.
+        const results = (await this.ctx.runQuery(
+          this.component.journal.loadBatchResults,
+          { batchStepId: entry._id },
+        )) as unknown as Array<{
+          index: number;
+          result: { kind: string; returnValue?: unknown; error?: string };
+        }>;
+        results.sort((a, b) => a.index - b.index);
+
+        // Resolve the first message (already dequeued).
+        this._completeBatchItem(message, results[0]);
+
+        // Dequeue and resolve the remaining count - 1 messages.
+        for (let i = 1; i < entry.step.count; i++) {
+          const msg = await this.receiver.get();
+          this._completeBatchItem(msg, results[i]);
+        }
+        continue;
+      }
+
+      // Regular replay: one entry per message.
       if (entry) {
+        this.journalEntries.shift();
         this.completeMessage(message, entry);
         continue;
       }
@@ -149,6 +180,23 @@ export class StepExecutor {
         break;
       case "failed":
         message.reject(new Error(entry.step.runResult.error));
+        break;
+      case "canceled":
+        message.reject(new Error("Canceled"));
+        break;
+    }
+  }
+
+  private _completeBatchItem(
+    message: StepRequest,
+    result: { index: number; result: { kind: string; returnValue?: unknown; error?: string } },
+  ) {
+    switch (result.result.kind) {
+      case "success":
+        message.resolve(result.result.returnValue);
+        break;
+      case "failed":
+        message.reject(new Error(result.result.error));
         break;
       case "canceled":
         message.reject(new Error("Canceled"));
@@ -225,34 +273,29 @@ export class StepExecutor {
   private async _startStepsBatch(
     messages: StepRequest[],
   ): Promise<JournalEntry[]> {
-    const steps = await Promise.all(
-      messages.map(async (message) => {
-        const step = await this._buildStep(message);
-        return {
-          retry: message.retry,
-          schedulerOptions: message.schedulerOptions,
-          step,
-        };
-      }),
-    );
-    const { entries, onCompleteHandle } = (await this.ctx.runMutation(
-      this.component.journal.startBatchSteps,
-      {
-        workflowId: this.workflowId,
-        generationNumber: this.generationNumber,
-        steps,
-        workpoolOptions: this.workpoolOptions,
-      },
-    )) as unknown as { entries: JournalEntry[]; onCompleteHandle: string };
-    this._checkJournalSize(entries);
+    // Create a single batchGroup step doc for all N messages.
+    const { entry, onCompleteHandle } =
+      (await this.ctx.runMutation(
+        this.component.journal.startBatchGroupStep,
+        {
+          workflowId: this.workflowId,
+          generationNumber: this.generationNumber,
+          count: messages.length,
+          workpoolOptions: this.workpoolOptions,
+        },
+      )) as unknown as {
+        entry: JournalEntry;
+        onCompleteHandle: string;
+      };
+    this._checkJournalSize([entry]);
 
-    // Enqueue each batch task with the onComplete handle
-    for (let i = 0; i < entries.length; i++) {
-      const entry = entries[i];
-      const target = messages[i].target;
+    // Build all batch tasks upfront.
+    const maxWorkers = (this.batch as any).options?.maxWorkers ?? 10;
+    const tasks = messages.map((message, i) => {
+      const target = message.target;
       if (target.kind !== "function") {
         throw new Error(
-          `Assertion failed: batch step ${entry._id} has unexpected target kind "${target.kind}"`,
+          `Assertion failed: batch step has unexpected target kind "${target.kind}"`,
         );
       }
       const handlerName = this.batch!.resolveHandlerName(
@@ -260,27 +303,44 @@ export class StepExecutor {
       );
       if (!handlerName) {
         throw new Error(
-          `Assertion failed: batch step ${entry._id} has no handler for "${safeFunctionName(target.function)}" despite passing isRegistered`,
+          `Assertion failed: batch step has no handler for "${safeFunctionName(target.function)}" despite passing isRegistered`,
         );
       }
-      await this.batch!.enqueueByHandle(
-        this.ctx,
-        handlerName,
-        entry.step.args as Record<string, unknown>,
-        {
-          onComplete: {
-            fnHandle: onCompleteHandle,
-            context: {
-              stepId: entry._id,
-              generationNumber: this.generationNumber,
-              workpoolOptions: this.workpoolOptions,
-            },
+      return {
+        name: handlerName,
+        args: target.args as Record<string, unknown>,
+        slot: Math.floor(Math.random() * maxWorkers),
+        onComplete: {
+          fnHandle: onCompleteHandle,
+          context: {
+            batchStepId: entry._id,
+            index: i,
           },
-          retry: messages[i].retry,
         },
-      );
+        retryBehavior: undefined,
+      };
+    });
+
+    // First enqueue triggers batchConfig setup (executor start).
+    await this.batch!.enqueueByHandle(
+      this.ctx,
+      tasks[0].name,
+      tasks[0].args,
+      { onComplete: tasks[0].onComplete, retry: messages[0].retry },
+    );
+
+    // Batch-enqueue the rest directly via the component mutation.
+    const remaining = tasks.slice(1);
+    const BATCH_SIZE = 500;
+    for (let i = 0; i < remaining.length; i += BATCH_SIZE) {
+      const chunk = remaining.slice(i, i + BATCH_SIZE);
+      await this.ctx.runMutation(this.batch!.component.batch.enqueueBatch, {
+        tasks: chunk,
+        batchConfig: undefined,
+      });
     }
-    return entries;
+    // Return single entry — always inProgress, triggers executorBlocked.
+    return [entry];
   }
 
   private async _buildStep(message: StepRequest) {

--- a/src/client/step.ts
+++ b/src/client/step.ts
@@ -56,6 +56,7 @@ export type StepRequest = {
 
 export class StepExecutor {
   private journalEntrySize: number;
+  private remainingMessageCount: number;
 
   constructor(
     private workflowId: string,
@@ -70,6 +71,13 @@ export class StepExecutor {
   ) {
     this.journalEntrySize = journalEntries.reduce(
       (size, entry) => size + journalEntrySize(entry),
+      0,
+    );
+    // Cache the total message count for getGenerationState (called on every
+    // Date.now()). A batchGroup entry covers `count` messages; others cover 1.
+    this.remainingMessageCount = journalEntries.reduce(
+      (count, entry) =>
+        count + (entry.step.kind === "batchGroup" ? entry.step.count : 1),
       0,
     );
 
@@ -88,6 +96,7 @@ export class StepExecutor {
       // Handle batchGroup replay: one entry covers N messages.
       if (entry && entry.step.kind === "batchGroup") {
         this.journalEntries.shift();
+        this.remainingMessageCount -= entry.step.count;
         if (entry.step.inProgress) {
           throw new Error(
             `Assertion failed: batchGroup entry still in progress`,
@@ -103,6 +112,22 @@ export class StepExecutor {
         }>;
         results.sort((a, b) => a.index - b.index);
 
+        // Validate results count and index integrity.
+        if (results.length !== entry.step.count) {
+          throw new Error(
+            `Batch result count mismatch for ${entry._id}: ` +
+              `expected ${entry.step.count} results but got ${results.length}`,
+          );
+        }
+        for (let i = 0; i < results.length; i++) {
+          if (results[i].index !== i) {
+            throw new Error(
+              `Batch result index mismatch for ${entry._id}: ` +
+                `expected index ${i} at position ${i} but got index ${results[i].index}`,
+            );
+          }
+        }
+
         // Resolve the first message (already dequeued).
         this._completeBatchItem(message, results[0]);
 
@@ -117,6 +142,7 @@ export class StepExecutor {
       // Regular replay: one entry per message.
       if (entry) {
         this.journalEntries.shift();
+        this.remainingMessageCount--;
         this.completeMessage(message, entry);
         continue;
       }
@@ -141,17 +167,21 @@ export class StepExecutor {
   }
 
   getGenerationState() {
-    if (this.journalEntries.length <= this.receiver.bufferSize) {
+    // Use cached message count (decremented as entries are consumed in run()).
+    if (this.remainingMessageCount <= this.receiver.bufferSize) {
       return { now: this.now, latest: true };
     }
-    return {
-      // We use the next entry's startedAt, since we're in code just before that
-      // step is invoked. We use the bufferSize, since multiple steps may be
-      // currently enqueued in one generation, but the code after it has already
-      // started executing.
-      now: this.journalEntries[this.receiver.bufferSize].step.startedAt,
-      latest: false,
-    };
+    // Find the entry that corresponds to the buffer boundary.
+    let accumulated = 0;
+    for (const entry of this.journalEntries) {
+      const entryMessages =
+        entry.step.kind === "batchGroup" ? entry.step.count : 1;
+      if (accumulated + entryMessages > this.receiver.bufferSize) {
+        return { now: entry.step.startedAt, latest: false };
+      }
+      accumulated += entryMessages;
+    }
+    return { now: this.now, latest: true };
   }
 
   completeMessage(message: StepRequest, entry: JournalEntry) {

--- a/src/client/step.ts
+++ b/src/client/step.ts
@@ -230,7 +230,7 @@ export class StepExecutor {
         steps,
         workpoolOptions: this.workpoolOptions,
       },
-    )) as JournalEntry[];
+    )) as unknown as JournalEntry[];
     this._checkJournalSize(entries);
     return entries;
   }
@@ -256,12 +256,13 @@ export class StepExecutor {
         steps,
         workpoolOptions: this.workpoolOptions,
       },
-    )) as { entries: JournalEntry[]; onCompleteHandle: string };
+    )) as unknown as { entries: JournalEntry[]; onCompleteHandle: string };
     this._checkJournalSize(entries);
 
     // Enqueue each batch task with the onComplete handle
-    for (const entry of entries) {
-      const target = messages[entries.indexOf(entry)].target;
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      const target = messages[i].target;
       if (target.kind !== "function") continue;
       const handlerName = this.batch!.resolveHandlerName(
         safeFunctionName(target.function),
@@ -280,7 +281,7 @@ export class StepExecutor {
               workpoolOptions: this.workpoolOptions,
             },
           },
-          retry: messages[entries.indexOf(entry)].retry,
+          retry: messages[i].retry,
         },
       );
     }

--- a/src/client/step.ts
+++ b/src/client/step.ts
@@ -161,52 +161,39 @@ export class StepExecutor {
       return this._startStepsRegular(messages);
     }
 
-    // Split messages into batch-eligible and regular
-    const batchIndices: number[] = [];
-    const regularIndices: number[] = [];
-    for (let i = 0; i < messages.length; i++) {
-      const target = messages[i].target;
-      if (
+    // Classify each message as batch-eligible or regular.
+    const isBatch = messages.map((message) => {
+      const target = message.target;
+      return (
         target.kind === "function" &&
         target.functionType === "action" &&
-        this.batch.isRegistered(safeFunctionName(target.function))
-      ) {
-        batchIndices.push(i);
-      } else {
-        regularIndices.push(i);
-      }
-    }
+        this.batch!.isRegistered(safeFunctionName(target.function))
+      );
+    });
 
-    if (batchIndices.length === 0) {
+    if (isBatch.every((b) => !b)) {
       return this._startStepsRegular(messages);
     }
 
-    // Process sequentially to avoid step number collisions.
-    // Batch messages first, then regular.
-    const allEntries: Array<{ index: number; entry: JournalEntry }> = [];
-
-    if (batchIndices.length > 0) {
-      const batchMessages = batchIndices.map((i) => messages[i]);
-      const batchEntries = await this._startStepsBatch(batchMessages);
-      for (let i = 0; i < batchIndices.length; i++) {
-        allEntries.push({ index: batchIndices[i], entry: batchEntries[i] });
+    // Process contiguous groups in original order so step numbers are assigned
+    // sequentially matching message order. This is critical for correctness on
+    // resume: journal entries are loaded by stepNumber, and the handler replays
+    // messages in original order, so the two must match.
+    const allEntries: JournalEntry[] = [];
+    let i = 0;
+    while (i < messages.length) {
+      const groupIsBatch = isBatch[i];
+      const groupStart = i;
+      while (i < messages.length && isBatch[i] === groupIsBatch) {
+        i++;
       }
+      const groupMessages = messages.slice(groupStart, i);
+      const groupEntries = groupIsBatch
+        ? await this._startStepsBatch(groupMessages)
+        : await this._startStepsRegular(groupMessages);
+      allEntries.push(...groupEntries);
     }
-
-    if (regularIndices.length > 0) {
-      const regularMessages = regularIndices.map((i) => messages[i]);
-      const regularEntries = await this._startStepsRegular(regularMessages);
-      for (let i = 0; i < regularIndices.length; i++) {
-        allEntries.push({
-          index: regularIndices[i],
-          entry: regularEntries[i],
-        });
-      }
-    }
-
-    // Merge back in original message order
-    allEntries.sort((a, b) => a.index - b.index);
-    return allEntries.map((e) => e.entry);
+    return allEntries;
   }
 
   private async _startStepsRegular(
@@ -263,11 +250,19 @@ export class StepExecutor {
     for (let i = 0; i < entries.length; i++) {
       const entry = entries[i];
       const target = messages[i].target;
-      if (target.kind !== "function") continue;
+      if (target.kind !== "function") {
+        throw new Error(
+          `Assertion failed: batch step ${entry._id} has unexpected target kind "${target.kind}"`,
+        );
+      }
       const handlerName = this.batch!.resolveHandlerName(
         safeFunctionName(target.function),
       );
-      if (!handlerName) continue;
+      if (!handlerName) {
+        throw new Error(
+          `Assertion failed: batch step ${entry._id} has no handler for "${safeFunctionName(target.function)}" despite passing isRegistered`,
+        );
+      }
       await this.batch!.enqueueByHandle(
         this.ctx,
         handlerName,

--- a/src/client/workflowMutation.ts
+++ b/src/client/workflowMutation.ts
@@ -20,7 +20,11 @@ import type { WorkflowDefinition } from "./index.js";
 import { StepExecutor, type StepRequest, type WorkerResult } from "./step.js";
 import { createWorkflowCtx } from "./workflowContext.js";
 import { checkArgs } from "./validator.js";
-import { type RunResult, type WorkpoolOptions } from "@convex-dev/workpool";
+import {
+  type BatchWorkpool,
+  type RunResult,
+  type WorkpoolOptions,
+} from "@convex-dev/workpool";
 import { type WorkflowComponent } from "./types.js";
 import { vWorkflowId } from "../types.js";
 import { formatErrorWithStack } from "../shared.js";
@@ -46,6 +50,7 @@ export function workflowMutation<ArgsValidator extends PropertyValidators>(
   component: WorkflowComponent,
   registered: WorkflowDefinition<ArgsValidator>,
   defaultWorkpoolOptions?: WorkpoolOptions,
+  batch?: BatchWorkpool,
 ): RegisteredMutation<
   "internal",
   {
@@ -127,6 +132,7 @@ export function workflowMutation<ArgsValidator extends PropertyValidators>(
         channel,
         Date.now(),
         workpoolOptions,
+        batch,
       );
       setupEnvironment(executor.getGenerationState.bind(executor), workflowId);
 

--- a/src/client/workflowMutation.ts
+++ b/src/client/workflowMutation.ts
@@ -119,9 +119,13 @@ export function workflowMutation<ArgsValidator extends PropertyValidators>(
           `Assertion failed: not blocked but have in-progress journal entry`,
         );
       }
-      const channel = new BaseChannel<StepRequest>(
-        workpoolOptions.maxParallelism ?? 10,
-      );
+      // When batch is configured, use a large channel so the handler can push
+      // all batch messages (e.g. 1000 Promise.all items) in a single run,
+      // creating one batchGroup instead of many smaller ones across re-runs.
+      const channelCapacity = batch
+        ? Math.max(workpoolOptions.maxParallelism ?? 10, 10000)
+        : workpoolOptions.maxParallelism ?? 10;
+      const channel = new BaseChannel<StepRequest>(channelCapacity);
       const step = createWorkflowCtx(workflowId, channel);
       const executor = new StepExecutor(
         workflowId,

--- a/src/client/workflowMutation.ts
+++ b/src/client/workflowMutation.ts
@@ -128,7 +128,7 @@ export function workflowMutation<ArgsValidator extends PropertyValidators>(
         generationNumber,
         ctx,
         component,
-        journalEntries as JournalEntry[],
+        journalEntries as unknown as JournalEntry[],
         channel,
         Date.now(),
         workpoolOptions,

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -112,6 +112,20 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | { error: string; kind: "failed" }
                     | { kind: "canceled" };
                   startedAt: number;
+                }
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  count: number;
+                  inProgress: boolean;
+                  kind: "batchGroup";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
                 };
             stepNumber: number;
             workflowId: string;
@@ -134,6 +148,108 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             state?: any;
             workflowHandle: string;
           };
+        },
+        Name
+      >;
+      loadBatchResults: FunctionReference<
+        "query",
+        "internal",
+        { batchStepId: string },
+        Array<{
+          index: number;
+          result:
+            | { kind: "success"; returnValue: any }
+            | { error: string; kind: "failed" }
+            | { kind: "canceled" };
+        }>,
+        Name
+      >;
+      startBatchGroupStep: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          count: number;
+          generationNumber: number;
+          workflowId: string;
+          workpoolOptions?: {
+            defaultRetryBehavior?: {
+              base: number;
+              initialBackoffMs: number;
+              maxAttempts: number;
+            };
+            logLevel?: "DEBUG" | "TRACE" | "INFO" | "REPORT" | "WARN" | "ERROR";
+            maxParallelism?: number;
+            retryActionsByDefault?: boolean;
+          };
+        },
+        {
+          entry: {
+            _creationTime: number;
+            _id: string;
+            step:
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  functionType: "query" | "mutation" | "action";
+                  handle: string;
+                  inProgress: boolean;
+                  kind?: "function";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                  workId?: string;
+                }
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  handle: string;
+                  inProgress: boolean;
+                  kind: "workflow";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                  workflowId?: string;
+                }
+              | {
+                  args: { eventId?: string };
+                  argsSize: number;
+                  completedAt?: number;
+                  eventId?: string;
+                  inProgress: boolean;
+                  kind: "event";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                }
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  count: number;
+                  inProgress: boolean;
+                  kind: "batchGroup";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                };
+            stepNumber: number;
+            workflowId: string;
+          };
+          onCompleteHandle: string;
         },
         Name
       >;
@@ -186,6 +302,20 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                   eventId?: string;
                   inProgress: boolean;
                   kind: "event";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                }
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  count: number;
+                  inProgress: boolean;
+                  kind: "batchGroup";
                   name: string;
                   runResult?:
                     | { kind: "success"; returnValue: any }
@@ -255,6 +385,20 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | { error: string; kind: "failed" }
                     | { kind: "canceled" };
                   startedAt: number;
+                }
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  count: number;
+                  inProgress: boolean;
+                  kind: "batchGroup";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
                 };
             stepNumber: number;
             workflowId: string;
@@ -318,6 +462,20 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | { error: string; kind: "failed" }
                     | { kind: "canceled" };
                   startedAt: number;
+                }
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  count: number;
+                  inProgress: boolean;
+                  kind: "batchGroup";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
                 };
           }>;
           workflowId: string;
@@ -374,6 +532,20 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                 eventId?: string;
                 inProgress: boolean;
                 kind: "event";
+                name: string;
+                runResult?:
+                  | { kind: "success"; returnValue: any }
+                  | { error: string; kind: "failed" }
+                  | { kind: "canceled" };
+                startedAt: number;
+              }
+            | {
+                args: any;
+                argsSize: number;
+                completedAt?: number;
+                count: number;
+                inProgress: boolean;
+                kind: "batchGroup";
                 name: string;
                 runResult?:
                   | { kind: "success"; returnValue: any }
@@ -477,6 +649,20 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                   eventId?: string;
                   inProgress: boolean;
                   kind: "event";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                }
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  count: number;
+                  inProgress: boolean;
+                  kind: "batchGroup";
                   name: string;
                   runResult?:
                     | { kind: "success"; returnValue: any }

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -137,6 +137,132 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         },
         Name
       >;
+      startBatchSteps: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          generationNumber: number;
+          steps: Array<{
+            retry?:
+              | boolean
+              | { base: number; initialBackoffMs: number; maxAttempts: number };
+            schedulerOptions?: { runAt?: number } | { runAfter?: number };
+            step:
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  functionType: "query" | "mutation" | "action";
+                  handle: string;
+                  inProgress: boolean;
+                  kind?: "function";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                  workId?: string;
+                }
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  handle: string;
+                  inProgress: boolean;
+                  kind: "workflow";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                  workflowId?: string;
+                }
+              | {
+                  args: { eventId?: string };
+                  argsSize: number;
+                  completedAt?: number;
+                  eventId?: string;
+                  inProgress: boolean;
+                  kind: "event";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                };
+          }>;
+          workflowId: string;
+          workpoolOptions?: {
+            defaultRetryBehavior?: {
+              base: number;
+              initialBackoffMs: number;
+              maxAttempts: number;
+            };
+            logLevel?: "DEBUG" | "TRACE" | "INFO" | "REPORT" | "WARN" | "ERROR";
+            maxParallelism?: number;
+            retryActionsByDefault?: boolean;
+          };
+        },
+        {
+          entries: Array<{
+            _creationTime: number;
+            _id: string;
+            step:
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  functionType: "query" | "mutation" | "action";
+                  handle: string;
+                  inProgress: boolean;
+                  kind?: "function";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                  workId?: string;
+                }
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  handle: string;
+                  inProgress: boolean;
+                  kind: "workflow";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                  workflowId?: string;
+                }
+              | {
+                  args: { eventId?: string };
+                  argsSize: number;
+                  completedAt?: number;
+                  eventId?: string;
+                  inProgress: boolean;
+                  kind: "event";
+                  name: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                };
+            stepNumber: number;
+            workflowId: string;
+          }>;
+          onCompleteHandle: string;
+        },
+        Name
+      >;
       startSteps: FunctionReference<
         "mutation",
         "internal",

--- a/src/component/_generated/server.ts
+++ b/src/component/_generated/server.ts
@@ -107,11 +107,6 @@ export const internalAction: ActionBuilder<DataModel, "internal"> =
  */
 export const httpAction: HttpActionBuilder = httpActionGeneric;
 
-type GenericCtx =
-  | GenericActionCtx<DataModel>
-  | GenericMutationCtx<DataModel>
-  | GenericQueryCtx<DataModel>;
-
 /**
  * A set of services for use within Convex query functions.
  *

--- a/src/component/batchGroup.test.ts
+++ b/src/component/batchGroup.test.ts
@@ -1,0 +1,655 @@
+/// <reference types="vite/client" />
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { api, internal } from "./_generated/api.js";
+import { initConvexTest } from "./setup.test.js";
+import type { Id } from "./_generated/dataModel.js";
+
+/**
+ * Integration tests for batchGroup steps, exercising real Convex mutations
+ * against the convex-test in-memory backend.
+ *
+ * These test the component-side code that unit tests can't reach:
+ * - startBatchGroupStep (journal.ts)
+ * - onCompleteBatchGroupItem (pool.ts)
+ * - _checkBatchCompletion (pool.ts)
+ * - loadBatchResults (journal.ts)
+ * - cleanup with batchResults (workflow.ts)
+ * - cancel mid-batchGroup (workflow.ts)
+ */
+
+// Helper: create a workflow and return its ID + generationNumber
+async function createTestWorkflow(t: ReturnType<typeof initConvexTest>) {
+  const id = await t.mutation(api.workflow.create, {
+    workflowName: "batchTest",
+    workflowHandle: "function://internal.example.exampleWorkflow",
+    workflowArgs: {},
+    startAsync: true,
+  });
+  return { workflowId: id, generationNumber: 0 };
+}
+
+describe("startBatchGroupStep", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("creates a single step doc with kind=batchGroup", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    const result = await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 10,
+    });
+
+    expect(result.entry.step.kind).toBe("batchGroup");
+    expect(result.entry.step.count).toBe(10);
+    expect(result.entry.step.inProgress).toBe(true);
+    expect(result.entry.step.name).toBe("batchGroup");
+    expect(result.onCompleteHandle).toBeTruthy();
+  });
+
+  test("step has correct stepNumber based on existing steps", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    // Create a regular step first (stepNumber 0)
+    await t.mutation(api.journal.startSteps, {
+      workflowId,
+      generationNumber,
+      steps: [
+        {
+          step: {
+            kind: "function" as const,
+            functionType: "action" as const,
+            handle: "function://test",
+            name: "regularStep",
+            inProgress: true,
+            argsSize: 2,
+            args: {},
+            startedAt: Date.now(),
+          },
+        },
+      ],
+    });
+
+    // Now create a batchGroup step (should be stepNumber 1)
+    const result = await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 5,
+    });
+
+    expect(result.entry.stepNumber).toBe(1);
+  });
+
+  test("schedules _checkBatchCompletion poller", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 3,
+    });
+
+    // The poller should have been scheduled. Running scheduled functions
+    // should trigger it (though it will just re-schedule since no results yet).
+    // We verify it doesn't crash.
+    const timer = vi.advanceTimersByTime;
+    await t.finishAllScheduledFunctions(timer);
+  });
+
+  test("rejects if workflow is already completed", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    // Cancel the workflow (marks it as completed)
+    await t.mutation(api.workflow.cancel, { workflowId });
+
+    // Should throw — either "not running" or "Invalid generation number"
+    // (cancel bumps generationNumber, so the old one is stale)
+    await expect(
+      t.mutation(api.journal.startBatchGroupStep, {
+        workflowId,
+        generationNumber,
+        count: 5,
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("onCompleteBatchGroupItem", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("inserts a result doc into batchResults", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    const { entry } = await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 3,
+    });
+
+    // Simulate item 0 completing
+    await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+      workId: "work_123" as any,
+      result: { kind: "success", returnValue: "result_0" },
+      context: { batchStepId: entry._id, index: 0 },
+    });
+
+    // Verify the result was inserted
+    const results = await t.query(api.journal.loadBatchResults, {
+      batchStepId: entry._id as Id<"steps">,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].index).toBe(0);
+    expect(results[0].result).toEqual({
+      kind: "success",
+      returnValue: "result_0",
+    });
+  });
+
+  test("multiple items create separate result docs (no OCC contention)", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    const { entry } = await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 5,
+    });
+
+    // Simulate all 5 items completing (in arbitrary order)
+    for (const i of [3, 0, 4, 1, 2]) {
+      await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+        workId: `work_${i}` as any,
+        result: { kind: "success", returnValue: `result_${i}` },
+        context: { batchStepId: entry._id, index: i },
+      });
+    }
+
+    // All 5 should be present
+    const results = await t.query(api.journal.loadBatchResults, {
+      batchStepId: entry._id as Id<"steps">,
+    });
+    expect(results).toHaveLength(5);
+    // Results should be sorted by index
+    for (let i = 0; i < 5; i++) {
+      expect(results[i].index).toBe(i);
+      expect(results[i].result).toEqual({
+        kind: "success",
+        returnValue: `result_${i}`,
+      });
+    }
+  });
+
+  test("handles failed and canceled results", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    const { entry } = await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 3,
+    });
+
+    await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+      workId: "w0" as any,
+      result: { kind: "success", returnValue: "ok" },
+      context: { batchStepId: entry._id, index: 0 },
+    });
+    await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+      workId: "w1" as any,
+      result: { kind: "failed", error: "boom" },
+      context: { batchStepId: entry._id, index: 1 },
+    });
+    await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+      workId: "w2" as any,
+      result: { kind: "canceled" },
+      context: { batchStepId: entry._id, index: 2 },
+    });
+
+    const results = await t.query(api.journal.loadBatchResults, {
+      batchStepId: entry._id as Id<"steps">,
+    });
+    expect(results).toHaveLength(3);
+    expect(results[0].result.kind).toBe("success");
+    expect(results[1].result.kind).toBe("failed");
+    expect(results[2].result.kind).toBe("canceled");
+  });
+
+  test("silently ignores invalid batchStepId", async () => {
+    const t = initConvexTest();
+
+    // Should not throw — just return without inserting
+    await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+      workId: "w0" as any,
+      result: { kind: "success", returnValue: "ok" },
+      context: { batchStepId: "invalid_id", index: 0 },
+    });
+  });
+});
+
+describe("_checkBatchCompletion", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("marks batchGroup complete when all results are in", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    const { entry } = await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 3,
+    });
+
+    // Insert all 3 results
+    for (let i = 0; i < 3; i++) {
+      await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+        workId: `w${i}` as any,
+        result: { kind: "success", returnValue: `r${i}` },
+        context: { batchStepId: entry._id, index: i },
+      });
+    }
+
+    // Run the poller — it should mark the step as complete
+    await t.mutation(internal.pool._checkBatchCompletion, {
+      workflowId,
+      generationNumber,
+    });
+
+    // Verify step is no longer in progress
+    const step = await t.run(async (ctx) => {
+      return ctx.db.get(entry._id as Id<"steps">);
+    });
+    expect(step).not.toBeNull();
+    expect(step!.step.inProgress).toBe(false);
+    expect(step!.step.runResult).toEqual({
+      kind: "success",
+      returnValue: null,
+    });
+  });
+
+  test("re-schedules poll when results are incomplete", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    const { entry } = await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 3,
+    });
+
+    // Insert only 1 of 3 results
+    await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+      workId: "w0" as any,
+      result: { kind: "success", returnValue: "r0" },
+      context: { batchStepId: entry._id, index: 0 },
+    });
+
+    // Run the poller — should NOT mark complete, should re-schedule
+    await t.mutation(internal.pool._checkBatchCompletion, {
+      workflowId,
+      generationNumber,
+    });
+
+    // Step should still be in progress
+    const step = await t.run(async (ctx) => {
+      return ctx.db.get(entry._id as Id<"steps">);
+    });
+    expect(step!.step.inProgress).toBe(true);
+  });
+
+  test("stops polling when workflow generationNumber changes", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 3,
+    });
+
+    // Cancel the workflow (bumps generationNumber)
+    await t.mutation(api.workflow.cancel, { workflowId });
+
+    // Run the poller with the OLD generationNumber — should be a no-op
+    // (no crash, no re-enqueue)
+    await t.mutation(internal.pool._checkBatchCompletion, {
+      workflowId,
+      generationNumber, // old generation
+    });
+
+    // Workflow should still be canceled
+    const status = await t.query(api.workflow.getStatus, { workflowId });
+    expect(status.workflow.runResult?.kind).toBe("canceled");
+  });
+
+  test("stops polling when workflow is already completed", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 2,
+    });
+
+    // Complete the workflow manually
+    await t.mutation(api.workflow.complete, {
+      workflowId,
+      generationNumber,
+      runResult: { kind: "success", returnValue: "done" },
+    });
+
+    // Poller should not crash or re-enqueue
+    await t.mutation(internal.pool._checkBatchCompletion, {
+      workflowId,
+      generationNumber,
+    });
+  });
+});
+
+describe("cleanup with batchResults", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("deletes batchResults when cleaning up a batchGroup workflow", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    const { entry } = await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 3,
+    });
+
+    // Insert results
+    for (let i = 0; i < 3; i++) {
+      await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+        workId: `w${i}` as any,
+        result: { kind: "success", returnValue: `r${i}` },
+        context: { batchStepId: entry._id, index: i },
+      });
+    }
+
+    // Mark step as complete
+    await t.mutation(internal.pool._checkBatchCompletion, {
+      workflowId,
+      generationNumber,
+    });
+
+    // Complete the workflow so cleanup is allowed
+    await t.mutation(api.workflow.cancel, { workflowId });
+
+    // Clean up
+    const cleaned = await t.mutation(api.workflow.cleanup, { workflowId });
+    expect(cleaned).toBe(true);
+
+    // Verify everything is gone
+    await t.run(async (ctx) => {
+      // Workflow doc gone
+      const workflow = await ctx.db.get(workflowId);
+      expect(workflow).toBeNull();
+
+      // Step doc gone
+      const step = await ctx.db.get(entry._id as Id<"steps">);
+      expect(step).toBeNull();
+
+      // All batchResults gone
+      const remaining = await ctx.db
+        .query("batchResults")
+        .withIndex("batchStep", (q) =>
+          q.eq("batchStepId", entry._id as Id<"steps">),
+        )
+        .collect();
+      expect(remaining).toHaveLength(0);
+    });
+  });
+
+  test("cleanup handles workflow with mixed regular + batchGroup steps", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    // Create a regular step
+    const regularEntries = await t.mutation(api.journal.startSteps, {
+      workflowId,
+      generationNumber,
+      steps: [
+        {
+          step: {
+            kind: "function" as const,
+            functionType: "action" as const,
+            handle: "function://test",
+            name: "regularStep",
+            inProgress: true,
+            argsSize: 2,
+            args: {},
+            startedAt: Date.now(),
+          },
+        },
+      ],
+    });
+
+    // Create a batchGroup step
+    const { entry: bgEntry } = await t.mutation(
+      api.journal.startBatchGroupStep,
+      {
+        workflowId,
+        generationNumber,
+        count: 2,
+      },
+    );
+
+    // Insert batch results
+    for (let i = 0; i < 2; i++) {
+      await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+        workId: `w${i}` as any,
+        result: { kind: "success", returnValue: `r${i}` },
+        context: { batchStepId: bgEntry._id, index: i },
+      });
+    }
+
+    // Cancel and cleanup
+    await t.mutation(api.workflow.cancel, { workflowId });
+    const cleaned = await t.mutation(api.workflow.cleanup, { workflowId });
+    expect(cleaned).toBe(true);
+
+    // Everything gone
+    await t.run(async (ctx) => {
+      const workflow = await ctx.db.get(workflowId);
+      expect(workflow).toBeNull();
+
+      // Both steps gone
+      const steps = await ctx.db
+        .query("steps")
+        .withIndex("workflow", (q) => q.eq("workflowId", workflowId))
+        .collect();
+      expect(steps).toHaveLength(0);
+
+      // All batchResults gone
+      const batchResults = await ctx.db.query("batchResults").collect();
+      expect(batchResults).toHaveLength(0);
+    });
+  });
+});
+
+describe("cancel mid-batchGroup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("canceling workflow with in-progress batchGroup bumps generationNumber", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    // Create batchGroup step (in progress)
+    const { entry } = await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 100,
+    });
+
+    // Cancel while batchGroup is in flight
+    await t.mutation(api.workflow.cancel, { workflowId });
+
+    // Verify workflow is canceled with bumped generationNumber
+    const status = await t.query(api.workflow.getStatus, { workflowId });
+    expect(status.workflow.runResult?.kind).toBe("canceled");
+    expect(status.workflow.generationNumber).toBe(generationNumber + 1);
+  });
+
+  test("results arriving after cancel don't crash", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    const { entry } = await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 3,
+    });
+
+    // Cancel
+    await t.mutation(api.workflow.cancel, { workflowId });
+
+    // Results arrive late — should not crash
+    for (let i = 0; i < 3; i++) {
+      await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+        workId: `w${i}` as any,
+        result: { kind: "success", returnValue: `r${i}` },
+        context: { batchStepId: entry._id, index: i },
+      });
+    }
+
+    // Results are still written (orphaned but harmless)
+    const results = await t.query(api.journal.loadBatchResults, {
+      batchStepId: entry._id as Id<"steps">,
+    });
+    expect(results).toHaveLength(3);
+  });
+
+  test("poller does not re-enqueue workflow after cancel", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    const { entry } = await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 2,
+    });
+
+    // Insert all results
+    for (let i = 0; i < 2; i++) {
+      await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+        workId: `w${i}` as any,
+        result: { kind: "success", returnValue: `r${i}` },
+        context: { batchStepId: entry._id, index: i },
+      });
+    }
+
+    // Cancel BEFORE poller runs
+    await t.mutation(api.workflow.cancel, { workflowId });
+
+    // Run poller with old generationNumber — should detect mismatch and stop
+    await t.mutation(internal.pool._checkBatchCompletion, {
+      workflowId,
+      generationNumber, // old generation, workflow was bumped
+    });
+
+    // Workflow should still be canceled, not re-enqueued
+    const status = await t.query(api.workflow.getStatus, { workflowId });
+    expect(status.workflow.runResult?.kind).toBe("canceled");
+  });
+});
+
+describe("loadBatchResults", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("returns results sorted by index", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    const { entry } = await t.mutation(api.journal.startBatchGroupStep, {
+      workflowId,
+      generationNumber,
+      count: 5,
+    });
+
+    // Insert in reverse order
+    for (let i = 4; i >= 0; i--) {
+      await t.mutation(internal.pool.onCompleteBatchGroupItem, {
+        workId: `w${i}` as any,
+        result: { kind: "success", returnValue: `r${i}` },
+        context: { batchStepId: entry._id, index: i },
+      });
+    }
+
+    const results = await t.query(api.journal.loadBatchResults, {
+      batchStepId: entry._id as Id<"steps">,
+    });
+    expect(results).toHaveLength(5);
+    for (let i = 0; i < 5; i++) {
+      expect(results[i].index).toBe(i);
+    }
+  });
+
+  test("returns empty array for non-existent batchStepId", async () => {
+    const t = initConvexTest();
+    const { workflowId, generationNumber } = await createTestWorkflow(t);
+
+    // Create a regular step (not batchGroup) to get a valid step ID
+    const entries = await t.mutation(api.journal.startSteps, {
+      workflowId,
+      generationNumber,
+      steps: [
+        {
+          step: {
+            kind: "function" as const,
+            functionType: "action" as const,
+            handle: "function://test",
+            name: "notBatch",
+            inProgress: true,
+            argsSize: 2,
+            args: {},
+            startedAt: Date.now(),
+          },
+        },
+      ],
+    });
+
+    // Query batchResults for a step that has no batch results
+    const results = await t.query(api.journal.loadBatchResults, {
+      batchStepId: entries[0]._id as Id<"steps">,
+    });
+    expect(results).toHaveLength(0);
+  });
+});

--- a/src/component/journal.ts
+++ b/src/component/journal.ts
@@ -1,4 +1,5 @@
 import { v } from "convex/values";
+import { vResultValidator } from "@convex-dev/workpool";
 import { mutation, query } from "./_generated/server.js";
 import {
   journalDocument,
@@ -58,6 +59,7 @@ export const load = query({
         };
       }
     }
+    const t0 = Date.now();
     for await (const entry of ctx.db
       .query("steps")
       .withIndex("workflow", (q) => q.eq("workflowId", workflowId))) {
@@ -66,6 +68,12 @@ export const load = query({
       if (journalSize > MAX_JOURNAL_SIZE) {
         return { journalEntries, workflow, logLevel, ok: false };
       }
+    }
+    if (journalEntries.length > 10) {
+      const elapsed = Date.now() - t0;
+      globalThis.console.info(
+        `[PERF] journal.load read ${journalEntries.length} entries in ${elapsed}ms (${journalSize} bytes)`,
+      );
     }
     return { journalEntries, workflow, logLevel, ok: true };
   },
@@ -139,6 +147,10 @@ export const startSteps = mutation({
               durationMs: step.completedAt! - step.startedAt,
             });
           }
+        } else if (step.kind === "batchGroup") {
+          throw new Error(
+            `batchGroup steps should use startBatchGroupStep, not startSteps`,
+          );
         } else if (step.kind === "workflow") {
           const workflowId = await createHandler(ctx, {
             workflowName: step.name,
@@ -241,7 +253,10 @@ export const startBatchSteps = mutation({
   handler: async (
     ctx,
     args,
-  ): Promise<{ entries: JournalEntry[]; onCompleteHandle: string }> => {
+  ): Promise<{
+    entries: JournalEntry[];
+    onCompleteHandle: string;
+  }> => {
     if (!args.steps.every((step) => step.step.inProgress)) {
       throw new Error(`Assertion failed: not in progress`);
     }
@@ -259,9 +274,23 @@ export const startBatchSteps = mutation({
       .first();
     const stepNumberBase = maxEntry ? maxEntry.stepNumber + 1 : 0;
     const onCompleteHandle = await createFunctionHandle(
-      internal.pool.onComplete,
+      internal.pool.onCompleteBatchStep,
     );
 
+    // Schedule a polling completion checker that will re-enqueue the
+    // workflow once all batch steps have finished. This avoids OCC
+    // contention from per-item counter updates.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.pool._checkBatchCompletion,
+      {
+        workflowId: workflow._id,
+        generationNumber,
+        workpoolOptions: args.workpoolOptions,
+      },
+    );
+
+    const t0 = Date.now();
     const entries = await Promise.all(
       args.steps.map(async (stepArgs, index) => {
         const stepNumber = stepNumberBase + index;
@@ -282,6 +311,108 @@ export const startBatchSteps = mutation({
         return entry;
       }),
     );
+    const elapsed = Date.now() - t0;
+    console.info(
+      `[PERF] startBatchSteps created ${entries.length} step docs in ${elapsed}ms`,
+    );
     return { entries, onCompleteHandle };
+  },
+});
+
+/**
+ * Creates a single "batchGroup" step doc for N batch items.
+ * Returns the entry plus an onComplete handle for individual item completions.
+ */
+export const startBatchGroupStep = mutation({
+  args: {
+    workflowId: v.string(),
+    generationNumber: v.number(),
+    count: v.number(),
+    workpoolOptions: v.optional(workpoolOptions),
+  },
+  returns: v.object({
+    entry: journalDocument,
+    onCompleteHandle: v.string(),
+  }),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    entry: JournalEntry;
+    onCompleteHandle: string;
+  }> => {
+    const { generationNumber } = args;
+    const workflow = await getWorkflow(ctx, args.workflowId, generationNumber);
+    const console = await getDefaultLogger(ctx);
+
+    if (workflow.runResult !== undefined) {
+      throw new Error(`Workflow not running: ${args.workflowId}`);
+    }
+    const maxEntry = await ctx.db
+      .query("steps")
+      .withIndex("workflow", (q) => q.eq("workflowId", workflow._id))
+      .order("desc")
+      .first();
+    const stepNumberBase = maxEntry ? maxEntry.stepNumber + 1 : 0;
+
+    const stepId = await ctx.db.insert("steps", {
+      workflowId: workflow._id,
+      stepNumber: stepNumberBase,
+      step: {
+        kind: "batchGroup" as const,
+        count: args.count,
+        name: "batchGroup",
+        inProgress: true,
+        argsSize: 0,
+        args: {},
+        runResult: undefined,
+        startedAt: Date.now(),
+        completedAt: undefined,
+      },
+    });
+    const entry = await ctx.db.get(stepId);
+    assert(entry, "Step not found");
+
+    const onCompleteHandle = await createFunctionHandle(
+      internal.pool.onCompleteBatchGroupItem,
+    );
+
+    // Schedule polling completion checker.
+    await ctx.scheduler.runAfter(0, internal.pool._checkBatchCompletion, {
+      workflowId: workflow._id,
+      generationNumber,
+      workpoolOptions: args.workpoolOptions,
+    });
+
+    console.event("started", {
+      workflowId: workflow._id,
+      workflowName: workflow.name,
+      stepName: "batchGroup",
+      stepNumber: stepNumberBase,
+    });
+
+    return { entry, onCompleteHandle };
+  },
+});
+
+/**
+ * Load all batch results for a batchGroup step, sorted by index.
+ */
+export const loadBatchResults = query({
+  args: {
+    batchStepId: v.id("steps"),
+  },
+  returns: v.array(
+    v.object({
+      index: v.number(),
+      result: vResultValidator,
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const results = await ctx.db
+      .query("batchResults")
+      .withIndex("batchStep", (q) => q.eq("batchStepId", args.batchStepId))
+      .collect();
+    return results.map((r) => ({ index: r.index, result: r.result }));
   },
 });

--- a/src/component/journal.ts
+++ b/src/component/journal.ts
@@ -210,3 +210,78 @@ export const startSteps = mutation({
     return entries;
   },
 });
+
+/**
+ * Like startSteps but does NOT enqueue to the workpool. Instead returns the
+ * journal entries plus an onComplete function handle string. The client uses
+ * this to enqueue batch tasks with the correct onComplete callback.
+ */
+export const startBatchSteps = mutation({
+  args: {
+    workflowId: v.string(),
+    generationNumber: v.number(),
+    steps: v.array(
+      v.object({
+        step,
+        retry: v.optional(v.union(v.boolean(), vRetryBehavior)),
+        schedulerOptions: v.optional(
+          v.union(
+            v.object({ runAt: v.optional(v.number()) }),
+            v.object({ runAfter: v.optional(v.number()) }),
+          ),
+        ),
+      }),
+    ),
+    workpoolOptions: v.optional(workpoolOptions),
+  },
+  returns: v.object({
+    entries: v.array(journalDocument),
+    onCompleteHandle: v.string(),
+  }),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ entries: JournalEntry[]; onCompleteHandle: string }> => {
+    if (!args.steps.every((step) => step.step.inProgress)) {
+      throw new Error(`Assertion failed: not in progress`);
+    }
+    const { generationNumber } = args;
+    const workflow = await getWorkflow(ctx, args.workflowId, generationNumber);
+    const console = await getDefaultLogger(ctx);
+
+    if (workflow.runResult !== undefined) {
+      throw new Error(`Workflow not running: ${args.workflowId}`);
+    }
+    const maxEntry = await ctx.db
+      .query("steps")
+      .withIndex("workflow", (q) => q.eq("workflowId", workflow._id))
+      .order("desc")
+      .first();
+    const stepNumberBase = maxEntry ? maxEntry.stepNumber + 1 : 0;
+    const onCompleteHandle = await createFunctionHandle(
+      internal.pool.onComplete,
+    );
+
+    const entries = await Promise.all(
+      args.steps.map(async (stepArgs, index) => {
+        const stepNumber = stepNumberBase + index;
+        const stepId = await ctx.db.insert("steps", {
+          workflowId: workflow._id,
+          stepNumber,
+          step: stepArgs.step,
+        });
+        const entry = await ctx.db.get(stepId);
+        assert(entry, "Step not found");
+
+        console.event("started", {
+          workflowId: workflow._id,
+          workflowName: workflow.name,
+          stepName: entry.step.name,
+          stepNumber,
+        });
+        return entry;
+      }),
+    );
+    return { entries, onCompleteHandle };
+  },
+});

--- a/src/component/pool.ts
+++ b/src/component/pool.ts
@@ -180,6 +180,21 @@ async function onCompleteHandler(
     }
     return;
   }
+  // Only re-enqueue the workflow when no in-progress steps remain.
+  // This avoids flooding the standard workpool with redundant re-runs
+  // (e.g. 1000 batch completions each triggering a workflow re-enqueue).
+  const remainingInProgress = await ctx.db
+    .query("steps")
+    .withIndex("inProgress", (q) =>
+      q.eq("step.inProgress", true).eq("workflowId", workflowId),
+    )
+    .first();
+  if (remainingInProgress) {
+    console.debug(
+      `Skipping workflow re-enqueue: ${workflowId} still has in-progress steps`,
+    );
+    return;
+  }
   const workpool = await getWorkpool(ctx, args.context.workpoolOptions);
   await enqueueWorkflow(ctx, workflow, workpool);
 }
@@ -201,6 +216,136 @@ export async function enqueueWorkflow(
     },
   );
 }
+
+// Lightweight onComplete for batch steps. Only patches the step doc with the
+// result — no shared counter, no index check, no workflow re-enqueue.
+// Re-enqueue is handled by _checkBatchCompletion (polling).
+export const onCompleteBatchStep = internalMutation({
+  args: {
+    workId: vWorkIdValidator,
+    result: vResultValidator,
+    context: v.any(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const { stepId } = args.context;
+    const normalizedStepId = ctx.db.normalizeId("steps", stepId);
+    if (!normalizedStepId) return;
+
+    // Patch step result directly — read step to spread, then patch.
+    const entry = await ctx.db.get(normalizedStepId);
+    if (!entry) return;
+    await ctx.db.patch(normalizedStepId, {
+      step: {
+        ...entry.step,
+        inProgress: false,
+        completedAt: Date.now(),
+        runResult: args.result,
+      },
+    });
+  },
+});
+
+// Lightweight onComplete for batchGroup items. Write-only: inserts a result doc
+// into batchResults — no read-modify-write, no OCC contention.
+export const onCompleteBatchGroupItem = internalMutation({
+  args: {
+    workId: vWorkIdValidator,
+    result: vResultValidator,
+    context: v.any(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const { batchStepId, index } = args.context;
+    const normalizedId = ctx.db.normalizeId("steps", batchStepId);
+    if (!normalizedId) return;
+    await ctx.db.insert("batchResults", {
+      batchStepId: normalizedId,
+      index,
+      result: args.result,
+    });
+  },
+});
+
+// Polling completion checker for batch steps. Scheduled from startBatchSteps
+// and startBatchGroupStep. For batchGroup steps, counts batchResults docs.
+// For legacy batch steps, checks the inProgress index.
+export const _checkBatchCompletion = internalMutation({
+  args: {
+    workflowId: v.id("workflows"),
+    generationNumber: v.number(),
+    workpoolOptions: v.optional(workpoolOptions),
+    _pollCount: v.optional(v.number()),
+    _firstPollAt: v.optional(v.number()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const pollCount = (args._pollCount ?? 0) + 1;
+    const firstPollAt = args._firstPollAt ?? Date.now();
+
+    // Find all in-progress steps for this workflow.
+    const inProgressSteps = await ctx.db
+      .query("steps")
+      .withIndex("inProgress", (q) =>
+        q.eq("step.inProgress", true).eq("workflowId", args.workflowId),
+      )
+      .collect();
+
+    let anyRemaining = false;
+    for (const step of inProgressSteps) {
+      if (step.step.kind === "batchGroup") {
+        // Count batchResults for this batchGroup step.
+        // Use take(count) to stop reading early when not all results are in.
+        const results = await ctx.db
+          .query("batchResults")
+          .withIndex("batchStep", (q) => q.eq("batchStepId", step._id))
+          .take(step.step.count);
+        if (results.length >= step.step.count) {
+          // All items complete — mark the batchGroup step as done.
+          await ctx.db.patch(step._id, {
+            step: {
+              ...step.step,
+              inProgress: false,
+              completedAt: Date.now(),
+              runResult: { kind: "success", returnValue: null },
+            },
+          });
+          // There may be other in-progress steps; continue checking.
+        } else {
+          anyRemaining = true;
+        }
+      } else {
+        // Legacy batch step or other in-progress step — still waiting.
+        anyRemaining = true;
+      }
+    }
+
+    if (anyRemaining) {
+      // Not done yet — poll again in 200ms.
+      await ctx.scheduler.runAfter(
+        200,
+        internal.pool._checkBatchCompletion,
+        {
+          ...args,
+          _pollCount: pollCount,
+          _firstPollAt: firstPollAt,
+        },
+      );
+      return;
+    }
+    // All batch steps done — re-enqueue the workflow.
+    const elapsed = ((Date.now() - firstPollAt) / 1000).toFixed(1);
+    const console = await getDefaultLogger(ctx);
+    console.info(
+      `[PERF] Batch completion detected after ${pollCount} polls (${elapsed}s)`,
+    );
+    const workflow = await getWorkflow(ctx, args.workflowId, null);
+    if (workflow.runResult !== undefined) return;
+    if (workflow.generationNumber !== args.generationNumber) return;
+    const workpool = await getWorkpool(ctx, args.workpoolOptions);
+    await enqueueWorkflow(ctx, workflow, workpool);
+  },
+});
 
 export type OnComplete =
   typeof onComplete extends RegisteredAction<

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -89,6 +89,11 @@ export const step = v.union(
     eventId: v.optional(v.id("events")),
     args: v.object({ eventId: v.optional(v.id("events")) }),
   }),
+  v.object({
+    kind: v.literal("batchGroup"),
+    count: v.number(),
+    ...stepCommonFields,
+  }),
 );
 export type Step = Infer<typeof step>;
 
@@ -110,6 +115,9 @@ function stepSize(step: Step): number {
       break;
     case "event":
       size += step.eventId?.length ?? 0;
+      break;
+    case "batchGroup":
+      size += 8; // count field
       break;
   }
   size += 8 + step.argsSize;
@@ -184,6 +192,11 @@ export default defineSchema({
     "workflowId",
     "state.kind",
   ]),
+  batchResults: defineTable({
+    batchStepId: v.id("steps"),
+    index: v.number(),
+    result: vResultValidator,
+  }).index("batchStep", ["batchStepId", "index"]),
   onCompleteFailures: defineTable(
     v.union(
       v.object({

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -152,10 +152,15 @@ function publicStep(step: JournalEntry): WorkflowStep {
             kind: "workflow",
             nestedWorkflowId: publicWorkflowId(step.step.workflowId!),
           }
-        : {
-            kind: "function",
-            workId: step.step.workId!,
-          }),
+        : step.step.kind === "batchGroup"
+          ? {
+              kind: "function" as const,
+              workId: undefined!,
+            }
+          : {
+              kind: "function",
+              workId: step.step.workId!,
+            }),
   } satisfies WorkflowStep;
 }
 
@@ -289,6 +294,9 @@ export async function completeHandler(
               workflowId: step.workflowId,
             });
           }
+        } else if (step.kind === "batchGroup") {
+          // Batch items don't have individual workIds — the generationNumber
+          // bump prevents the poller from re-enqueuing the workflow.
         }
       }
     }
@@ -352,6 +360,17 @@ export const cleanup = mutation({
       .collect();
     for (const journalEntry of journalEntries) {
       logger.debug("Deleting journal entry", journalEntry);
+      if (journalEntry.step.kind === "batchGroup") {
+        const results = await ctx.db
+          .query("batchResults")
+          .withIndex("batchStep", (q) =>
+            q.eq("batchStepId", journalEntry._id),
+          )
+          .collect();
+        for (const r of results) {
+          await ctx.db.delete(r._id);
+        }
+      }
       await ctx.db.delete(journalEntry._id);
     }
     return true;


### PR DESCRIPTION
feat: integrate BatchWorkpool with workflow step execution

Route step.runAction() through BatchWorkpool when the action is
batch-registered. Pass `batch` option to WorkflowManager, which threads
it through to StepExecutor. Adds startBatchSteps mutation that creates
journal entries without enqueueing to workpool, returning an onComplete
handle for the client to use with batch.enqueueByHandle().

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

feat: add IO-constrained LLM simulation workflow demo

Add a demo workflow that simulates a complex IO-constrained pipeline
(like LLM generation) to compare regular workpool vs batched workpool.
The pipeline generates an outline, 200 parallel sections, and a summary,
demonstrating how BatchWorkpool processes all 200 sections concurrently
inside a single executor action vs requiring separate action slots.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

feat: save per-step results and increase batch parallelism

Store outline, sections, and summary progressively in the
llmSimulations table as each workflow step completes. Set
maxParallelism to 200 for batched workflow so all sections
dispatch in a single tick.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch processing support for high-throughput workflow steps and BatchWorkpool integration; LLM simulation pipelines now support regular and batched execution.

* **Schema**
  * Added llmSimulations and batchResults tables and a new batchGroup step type.

* **Documentation**
  * New README section on high-throughput BatchWorkpool usage.

* **Bug Fixes**
  * Improved batch completion handling to avoid premature re-enqueue and handle in-progress steps safely.

* **Tests**
  * Extensive tests for batch/group replay, ordering, and edge cases.

* **Chores**
  * Updated dev dependency source for the workpool package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->