### PR TITLE
surface ctx.getHistory() -> { size, stepCount }

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           npm i
           npm run build
       - name: Publish package for testing branch
-        run: npx pkg-pr-new publish || echo "Have you set up pkg-pr-new for this repo?"
+        run: npx pkg-pr-new publish || echo "pkg-pr-new failed"
       - name: Test
         run: |
           npm run test

--- a/README.md
+++ b/README.md
@@ -785,9 +785,10 @@ Here are a few limitations to keep in mind:
 - The workflow body is internally a mutation, with each step's return value read
   from the database on each subsequent step. As a result, the limits for a
   mutation apply and limit the number and size of steps you can perform
-  (including the workflow state overhead). There is currently an 8MiB limit
-  imposed on the journal size, to stay well within the mutation bounds. See more
-  about mutation limits here:
+  (including the workflow state overhead). **There is currently an 8MiB limit
+  imposed on the journal size**, to stay well within the mutation bounds. See
+  tip below for monitoring the journal size and step count during execution. See
+  more about mutation limits here:
   https://docs.convex.dev/production/state/limits#transactions
 - If you need to use side effects like `fetch` or use crypto.subtle, you'll need
   to do that in a step, not in the workflow definition.
@@ -799,6 +800,27 @@ Here are a few limitations to keep in mind:
   implementation should stay stable for the lifetime of active workflows. See
   [this issue](https://github.com/get-convex/workflow/issues/35) for ideas on
   how to make this better.
+
+**Tip:** Use `ctx.getHistory()` to get the current journal size and step count.
+This is useful for workflows that poll in a loop, so you can bail out before
+hitting the limit.
+
+```ts
+while (true) {
+  const result = await ctx.runAction(
+    internal.example.pollForResult,
+    { id },
+    { runAfter: 1000 }, // Poll every second
+  );
+  if (result !== null) {
+    return result;
+  }
+  const { stepCount, size } = ctx.getHistory();
+  if (stepCount > 100 || size > 2_000_000) {
+    return null;
+  }
+}
+```
 
 Open a [GitHub issue](https://github.com/get-convex/workflow/issues) with any
 feedback or bugs you find.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ export const userOnboarding = workflow.define({
     }
     const email = await step.runMutation(
       internal.emails.sendWelcomeEmail,
-      { userId: args.userId, content: result.content, },
+      { userId: args.userId, content: result.content },
       // Optimization: run the mutation synchronously from this transaction.
       { inline: true },
     );
@@ -289,9 +289,8 @@ await step.sleep(24 * 60 * 60 * 1000);
 
 Tip: You can name the sleep step for clarity with a second `{ name }` argument.
 
-If you want to defer a specific step, you can use
-`runAfter` or `runAt` as scheduling options on any step. This delays that
-particular step's execution:
+If you want to defer a specific step, you can use `runAfter` or `runAt` as
+scheduling options on any step. This delays that particular step's execution:
 
 ```ts
 // Run this action 10 seconds from now.
@@ -299,8 +298,8 @@ await step.runAction(internal.example.myAction, args, { runAfter: 10_000 });
 ```
 
 This is roughly equivalent to doing a sleep first, with the difference being
-that the "myAction" step is considered "in progress" while it is waiting, and
-it only enqueues one item into the Workpool (myAction@delay), instead of two
+that the "myAction" step is considered "in progress" while it is waiting, and it
+only enqueues one item into the Workpool (myAction@delay), instead of two
 (sleep@delay, myAction@now).
 
 ### Specifying retry behavior

--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ Here are a few limitations to keep in mind:
   [this issue](https://github.com/get-convex/workflow/issues/35) for ideas on
   how to make this better.
 
-**Tip:** Use `ctx.getHistory()` to get the current journal size and step count.
+**Tip:** Use `step.meta.getHistory()` to get the current journal size and step count.
 This is useful for workflows that poll in a loop, so you can bail out before
 hitting the limit.
 
@@ -814,7 +814,7 @@ while (true) {
   if (result !== null) {
     return result;
   }
-  const { stepCount, size } = ctx.getHistory();
+  const { stepCount, size } = step.meta.getHistory();
   if (stepCount > 100 || size > 2_000_000) {
     return null;
   }

--- a/example/convex/README.md
+++ b/example/convex/README.md
@@ -1,7 +1,7 @@
 # Welcome to your Convex functions directory!
 
-Write your Convex functions here.
-See https://docs.convex.dev/functions for more.
+Write your Convex functions here. See https://docs.convex.dev/functions for
+more.
 
 A query function that takes two arguments looks like:
 
@@ -85,6 +85,6 @@ function handleButtonPress() {
 }
 ```
 
-Use the Convex CLI to push your functions to a deployment. See everything
-the Convex CLI can do by running `npx convex -h` in your project root
-directory. To learn more, launch the docs with `npx convex docs`.
+Use the Convex CLI to push your functions to a deployment. See everything the
+Convex CLI can do by running `npx convex -h` in your project root directory. To
+learn more, launch the docs with `npx convex docs`.

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as admin from "../admin.js";
 import type * as catchError from "../catchError.js";
 import type * as e2e from "../e2e.js";
 import type * as example from "../example.js";
+import type * as historyExample from "../historyExample.js";
 import type * as inlineTest from "../inlineTest.js";
 import type * as nestedWorkflow from "../nestedWorkflow.js";
 import type * as passingSignals from "../passingSignals.js";
@@ -29,6 +30,7 @@ declare const fullApi: ApiFromModules<{
   catchError: typeof catchError;
   e2e: typeof e2e;
   example: typeof example;
+  historyExample: typeof historyExample;
   inlineTest: typeof inlineTest;
   nestedWorkflow: typeof nestedWorkflow;
   passingSignals: typeof passingSignals;

--- a/example/convex/historyExample.ts
+++ b/example/convex/historyExample.ts
@@ -9,7 +9,9 @@ export const historyWorkflow = workflow.define({
     const h0 = ctx.getHistory();
     console.log(`Before any steps: ${h0.stepCount} steps, ${h0.size} bytes`);
 
-    await ctx.runMutation(internal.historyExample.smallStep, { value: "hello" });
+    await ctx.runMutation(internal.historyExample.smallStep, {
+      value: "hello",
+    });
     const h1 = ctx.getHistory();
     console.log(`After step 1: ${h1.stepCount} steps, ${h1.size} bytes`);
 

--- a/example/convex/historyExample.ts
+++ b/example/convex/historyExample.ts
@@ -1,0 +1,53 @@
+import { v } from "convex/values";
+import { workflow } from "./example";
+import { internal } from "./_generated/api";
+import { internalAction, internalMutation } from "./_generated/server";
+
+export const historyWorkflow = workflow.define({
+  args: {},
+  handler: async (ctx) => {
+    const h0 = ctx.getHistory();
+    console.log(`Before any steps: ${h0.stepCount} steps, ${h0.size} bytes`);
+
+    await ctx.runMutation(internal.historyExample.smallStep, { value: "hello" });
+    const h1 = ctx.getHistory();
+    console.log(`After step 1: ${h1.stepCount} steps, ${h1.size} bytes`);
+
+    await ctx.runAction(internal.historyExample.mediumStep, {
+      data: "x".repeat(100),
+    });
+    const h2 = ctx.getHistory();
+    console.log(`After step 2: ${h2.stepCount} steps, ${h2.size} bytes`);
+
+    await ctx.runMutation(internal.historyExample.smallStep, {
+      value: "world",
+    });
+    const h3 = ctx.getHistory();
+    console.log(`After step 3: ${h3.stepCount} steps, ${h3.size} bytes`);
+
+    return {
+      finalStepCount: h3.stepCount,
+      finalSize: h3.size,
+    };
+  },
+  returns: v.object({
+    finalStepCount: v.number(),
+    finalSize: v.number(),
+  }),
+});
+
+export const smallStep = internalMutation({
+  args: { value: v.string() },
+  returns: v.string(),
+  handler: async (_ctx, args) => {
+    return `processed: ${args.value}`;
+  },
+});
+
+export const mediumStep = internalAction({
+  args: { data: v.string() },
+  returns: v.string(),
+  handler: async (_ctx, args) => {
+    return `echoed ${args.data.length} chars`;
+  },
+});

--- a/example/convex/historyExample.ts
+++ b/example/convex/historyExample.ts
@@ -5,26 +5,26 @@ import { internalAction, internalMutation } from "./_generated/server";
 
 export const historyWorkflow = workflow.define({
   args: {},
-  handler: async (ctx) => {
-    const h0 = ctx.getHistory();
+  handler: async (step) => {
+    const h0 = step.meta.getHistory();
     console.log(`Before any steps: ${h0.stepCount} steps, ${h0.size} bytes`);
 
-    await ctx.runMutation(internal.historyExample.smallStep, {
+    await step.runMutation(internal.historyExample.smallStep, {
       value: "hello",
     });
-    const h1 = ctx.getHistory();
+    const h1 = step.meta.getHistory();
     console.log(`After step 1: ${h1.stepCount} steps, ${h1.size} bytes`);
 
-    await ctx.runAction(internal.historyExample.mediumStep, {
+    await step.runAction(internal.historyExample.mediumStep, {
       data: "x".repeat(100),
     });
-    const h2 = ctx.getHistory();
+    const h2 = step.meta.getHistory();
     console.log(`After step 2: ${h2.stepCount} steps, ${h2.size} bytes`);
 
-    await ctx.runMutation(internal.historyExample.smallStep, {
+    await step.runMutation(internal.historyExample.smallStep, {
       value: "world",
     });
-    const h3 = ctx.getHistory();
+    const h3 = step.meta.getHistory();
     console.log(`After step 3: ${h3.stepCount} steps, ${h3.size} bytes`);
 
     return {

--- a/example/convex/nestedWorkflow.ts
+++ b/example/convex/nestedWorkflow.ts
@@ -6,7 +6,7 @@ import { internalMutation } from "./_generated/server";
 export const parentWorkflow = workflow.define({
   args: { prompt: v.string() },
   handler: async (step, args) => {
-    console.log("Starting confirmation workflow");
+    console.log("Starting parent workflow");
     const length = await step.runWorkflow(
       internal.nestedWorkflow.childWorkflow,
       { foo: args.prompt },

--- a/src/client/step.ts
+++ b/src/client/step.ts
@@ -96,7 +96,13 @@ export class StepExecutor {
   }
 
   getHistory() {
-    return { size: this.journalSize, stepCount: this.stepCount };
+    return {
+      // Technically the size may not match the stepCount if they check the size
+      // after adding a step but before it's finished - e.g. a non-awaited
+      // promise. The size only reflects finished steps
+      size: this.journalSize,
+      stepCount: this.stepCount + this.receiver.bufferSize,
+    };
   }
 
   getGenerationState() {

--- a/src/client/step.ts
+++ b/src/client/step.ts
@@ -53,7 +53,8 @@ export type StepRequest = {
 };
 
 export class StepExecutor {
-  private journalEntrySize: number;
+  private journalSize: number = 0;
+  private stepCount: number = 0;
 
   constructor(
     private workflowId: string,
@@ -64,17 +65,7 @@ export class StepExecutor {
     private receiver: BaseChannel<StepRequest>,
     private now: number,
     private workpoolOptions: WorkpoolOptions | undefined,
-  ) {
-    this.journalEntrySize = journalEntries.reduce(
-      (size, entry) => size + getConvexSize(entry),
-      0,
-    );
-
-    if (this.journalEntrySize > MAX_JOURNAL_SIZE) {
-      // This should never happen, but we'll throw an error just in case.
-      throw new Error(journalSizeError(this.journalEntrySize, this.workflowId));
-    }
-  }
+  ) {}
   async run(): Promise<WorkerResult> {
     while (true) {
       const message = await this.receiver.get();
@@ -94,8 +85,7 @@ export class StepExecutor {
       const entries = await this.startSteps(messages);
       if (entries.every((entry) => entry.step.runResult)) {
         for (let i = 0; i < entries.length; i++) {
-          const entry = entries[i];
-          this.completeMessage(messages[i], entry);
+          this.completeMessage(messages[i], entries[i]);
         }
         continue;
       }
@@ -103,6 +93,10 @@ export class StepExecutor {
         type: "executorBlocked",
       };
     }
+  }
+
+  getHistory() {
+    return { size: this.journalSize, stepCount: this.stepCount };
   }
 
   getGenerationState() {
@@ -120,6 +114,8 @@ export class StepExecutor {
   }
 
   completeMessage(message: StepRequest, entry: JournalEntry) {
+    this.stepCount++;
+    this.journalSize += getConvexSize(entry);
     if (entry.step.inProgress) {
       throw new Error(
         `Assertion failed: not blocked but have in-progress journal entry`,
@@ -231,10 +227,11 @@ export class StepExecutor {
       },
     )) as JournalEntry[];
     for (const entry of entries) {
-      this.journalEntrySize += getConvexSize(entry);
-      if (this.journalEntrySize > MAX_JOURNAL_SIZE) {
+      this.stepCount++;
+      this.journalSize += getConvexSize(entry);
+      if (this.journalSize > MAX_JOURNAL_SIZE) {
         throw new Error(
-          journalSizeError(this.journalEntrySize, this.workflowId) +
+          journalSizeError(this.journalSize, this.workflowId) +
             ` The failing step was ${entry.step.name} (${entry._id})`,
         );
       }

--- a/src/client/step.ts
+++ b/src/client/step.ts
@@ -206,16 +206,16 @@ export class StepExecutor {
                   ...commonFields,
                 }
               : target.kind === "event"
-              ? {
-                  kind: "event" as const,
-                  eventId: target.args.eventId,
-                  ...commonFields,
-                  args: target.args,
-                }
-              : {
-                  kind: "sleep" as const,
-                  ...commonFields,
-                };
+                ? {
+                    kind: "event" as const,
+                    eventId: target.args.eventId,
+                    ...commonFields,
+                    args: target.args,
+                  }
+                : {
+                    kind: "sleep" as const,
+                    ...commonFields,
+                  };
         return {
           retry: message.retry,
           schedulerOptions: message.schedulerOptions,

--- a/src/client/stepContext.test.ts
+++ b/src/client/stepContext.test.ts
@@ -97,7 +97,10 @@ async function replayFromJournal(
 describe("StepExecutor + WorkflowCtx integration", () => {
   it("resolves a successful step", async () => {
     const channel = new BaseChannel<StepRequest>(0);
-    const ctx = createWorkflowCtx("wf-1" as any, channel);
+    const ctx = createWorkflowCtx("wf-1" as any, channel, () => ({
+      size: 0,
+      stepCount: 0,
+    }));
 
     const entry = journalEntry({
       name: "test",
@@ -114,7 +117,10 @@ describe("StepExecutor + WorkflowCtx integration", () => {
 
   it("throws on a failed step and the error is catchable", async () => {
     const channel = new BaseChannel<StepRequest>(0);
-    const ctx = createWorkflowCtx("wf-2" as any, channel);
+    const ctx = createWorkflowCtx("wf-2" as any, channel, () => ({
+      size: 0,
+      stepCount: 0,
+    }));
 
     const entry = journalEntry({
       name: "test",
@@ -132,7 +138,10 @@ describe("StepExecutor + WorkflowCtx integration", () => {
 
   it("throws on a canceled step", async () => {
     const channel = new BaseChannel<StepRequest>(0);
-    const ctx = createWorkflowCtx("wf-3" as any, channel);
+    const ctx = createWorkflowCtx("wf-3" as any, channel, () => ({
+      size: 0,
+      stepCount: 0,
+    }));
 
     const entry = journalEntry({
       name: "test",
@@ -150,7 +159,10 @@ describe("StepExecutor + WorkflowCtx integration", () => {
 
   it("handles sequential steps", async () => {
     const channel = new BaseChannel<StepRequest>(0);
-    const ctx = createWorkflowCtx("wf-4" as any, channel);
+    const ctx = createWorkflowCtx("wf-4" as any, channel, () => ({
+      size: 0,
+      stepCount: 0,
+    }));
 
     const entries = [
       journalEntry({
@@ -183,7 +195,10 @@ describe("StepExecutor + WorkflowCtx integration", () => {
 
   it("catches an error mid-workflow and continues", async () => {
     const channel = new BaseChannel<StepRequest>(0);
-    const ctx = createWorkflowCtx("wf-5" as any, channel);
+    const ctx = createWorkflowCtx("wf-5" as any, channel, () => ({
+      size: 0,
+      stepCount: 0,
+    }));
 
     const entries = [
       journalEntry({
@@ -220,7 +235,10 @@ describe("StepExecutor + WorkflowCtx integration", () => {
 
   it("handles parallel steps via Promise.all", async () => {
     const channel = new BaseChannel<StepRequest>(0);
-    const ctx = createWorkflowCtx("wf-6" as any, channel);
+    const ctx = createWorkflowCtx("wf-6" as any, channel, () => ({
+      size: 0,
+      stepCount: 0,
+    }));
 
     const entries = [
       journalEntry({
@@ -254,7 +272,10 @@ describe("StepExecutor + WorkflowCtx integration", () => {
 
   it("one failure in Promise.all rejects the batch", async () => {
     const channel = new BaseChannel<StepRequest>(0);
-    const ctx = createWorkflowCtx("wf-7" as any, channel);
+    const ctx = createWorkflowCtx("wf-7" as any, channel, () => ({
+      size: 0,
+      stepCount: 0,
+    }));
 
     const entries = [
       journalEntry({
@@ -289,7 +310,10 @@ describe("StepExecutor + WorkflowCtx integration", () => {
 
   it("error is thrown from run(), not from completeMessage", async () => {
     const channel = new BaseChannel<StepRequest>(0);
-    const ctx = createWorkflowCtx("wf-8" as any, channel);
+    const ctx = createWorkflowCtx("wf-8" as any, channel, () => ({
+      size: 0,
+      stepCount: 0,
+    }));
 
     const entry = journalEntry({
       name: "test",
@@ -312,7 +336,10 @@ describe("StepExecutor + WorkflowCtx integration", () => {
 
   it("runMutation works the same as runAction", async () => {
     const channel = new BaseChannel<StepRequest>(0);
-    const ctx = createWorkflowCtx("wf-9" as any, channel);
+    const ctx = createWorkflowCtx("wf-9" as any, channel, () => ({
+      size: 0,
+      stepCount: 0,
+    }));
 
     const entry = journalEntry({
       name: "mut",
@@ -329,7 +356,10 @@ describe("StepExecutor + WorkflowCtx integration", () => {
 
   it("runQuery works the same as runAction", async () => {
     const channel = new BaseChannel<StepRequest>(0);
-    const ctx = createWorkflowCtx("wf-10" as any, channel);
+    const ctx = createWorkflowCtx("wf-10" as any, channel, () => ({
+      size: 0,
+      stepCount: 0,
+    }));
 
     const entry = journalEntry({
       name: "qry",

--- a/src/client/workflowContext.ts
+++ b/src/client/workflowContext.ts
@@ -126,11 +126,16 @@ export type WorkflowCtx = {
    */
   sleep(duration: number, opts?: { name?: string }): Promise<void>;
   /**
-   * Get the current history of the workflow execution.
-   *
-   * @returns The size in bytes and number of steps processed so far.
+   * Metadata about the workflow execution.
    */
-  getHistory: () => { size: number; stepCount: number };
+  meta: {
+    /**
+     * Get the current history of the workflow execution.
+     *
+     * @returns The size in bytes and number of steps processed so far.
+     */
+    getHistory: () => { size: number; stepCount: number };
+  };
 };
 
 export type OptionalRestArgs<
@@ -148,7 +153,7 @@ export function createWorkflowCtx(
 ) {
   return {
     workflowId,
-    getHistory,
+    meta: { getHistory },
     runQuery: async (query, args, opts?) => {
       return runFunction(sender, "query", query, args, opts);
     },

--- a/src/client/workflowContext.ts
+++ b/src/client/workflowContext.ts
@@ -125,6 +125,12 @@ export type WorkflowCtx = {
    * @param opts - Optionally name the step. Default: "sleep"
    */
   sleep(duration: number, opts?: { name?: string }): Promise<void>;
+  /**
+   * Get the current history of the workflow execution.
+   *
+   * @returns The size in bytes and number of steps processed so far.
+   */
+  getHistory: () => { size: number; stepCount: number };
 };
 
 export type OptionalRestArgs<
@@ -138,9 +144,11 @@ export type OptionalRestArgs<
 export function createWorkflowCtx(
   workflowId: WorkflowId,
   sender: BaseChannel<StepRequest>,
+  getHistory: () => { size: number; stepCount: number },
 ) {
   return {
     workflowId,
+    getHistory,
     runQuery: async (query, args, opts?) => {
       return runFunction(sender, "query", query, args, opts);
     },

--- a/src/client/workflowMutation.ts
+++ b/src/client/workflowMutation.ts
@@ -117,7 +117,6 @@ export function workflowMutation<ArgsValidator extends PropertyValidators>(
       const channel = new BaseChannel<StepRequest>(
         workpoolOptions.maxParallelism ?? 10,
       );
-      const step = createWorkflowCtx(workflowId, channel);
       const executor = new StepExecutor(
         workflowId,
         generationNumber,
@@ -127,6 +126,11 @@ export function workflowMutation<ArgsValidator extends PropertyValidators>(
         channel,
         Date.now(),
         workpoolOptions,
+      );
+      const step = createWorkflowCtx(
+        workflowId,
+        channel,
+        executor.getHistory.bind(executor),
       );
       const restoreEnvironment = setupEnvironment(
         executor.getGenerationState.bind(executor),


### PR DESCRIPTION
Adds workflow history tracking with a new `ctx.getHistory()` method to monitor workflow execution metrics.

Fixes #178

### What changed?

- Refactored `StepExecutor` to track workflow execution metrics:
  - Replaced `journalEntrySize` with `journalSize` and added `stepCount` to track both total size and number of steps
  - Added a `getHistory()` method that returns these metrics
  - Modified journal size tracking to increment as steps are processed rather than calculating upfront
- Exposed the history tracking functionality to workflow context:
  - Added a `getHistory()` method to the `WorkflowCtx` type
  - Updated the `createWorkflowCtx` function to accept and expose the history getter

### How to test?

1. Create a workflow that calls `ctx.getHistory()`
2. Run the workflow and verify it returns an object with `size` and `stepCount` properties
3. Run multiple steps in the workflow and check that the metrics increase appropriately
4. Verify that journal size limits are still enforced correctly

### Why make this change?

This change provides developers with visibility into workflow execution metrics, allowing them to monitor the size and complexity of their workflows. This is particularly useful for debugging performance issues and preventing workflows from hitting size limits unexpectedly. The incremental tracking approach is also more efficient than calculating the entire journal size upfront.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed getHistory() on workflow context to read current journal size and step count during execution.

* **Documentation**
  * Emphasized 8MiB journal-size guidance, added a monitoring tip and polling example for early exit based on size/stepCount, and reflowed README text for readability.

* **Examples**
  * Added a workflow example that logs execution-history metrics and demonstrates step calls.

* **Tests**
  * Updated tests to include getHistory() in workflow context setup.

* **Chore**
  * Clarified a console message and a CI publish-step message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->