### PR TITLE
Allow racing multiple events

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,122 @@ See [`example/convex/passingSignals.ts`](./example/convex/passingSignals.ts) for
 a complete example of creating events, passing their IDs around, and sending
 signals.
 
+### Racing multiple events with `step.raceEvents`
+
+Use `step.raceEvents` to wait for whichever of several events fires first, then
+continue based on which one won. This is useful for approval flows (approve or
+reject), user choices, or any "first-of-many" scenario.
+
+Pass an array of the events to wait for, and the workflow pauses until one
+arrives. The result tells you which event won, and its value is typed to match:
+
+```ts
+const approvalEvent = defineEvent({
+  name: "approval",
+  validator: v.object({ proposal: v.string() }),
+});
+const rejectionEvent = defineEvent({
+  name: "rejection",
+  validator: v.object({ reason: v.string() }),
+});
+
+export const myWorkflow = workflow.define({
+  args: {},
+  returns: v.string(),
+  handler: async (step): Promise<string> => {
+    const result = await step.raceEvents([approvalEvent, rejectionEvent]);
+
+    if (result.name === "approval") {
+      return `Approved: ${result.value.proposal}`;
+    } else {
+      return `Rejected: ${result.value.reason}`;
+    }
+  },
+});
+```
+
+Fire the winning event from a mutation or action with `sendEvent`, exactly as
+you would for a single `awaitEvent`:
+
+```ts
+await sendEvent(ctx, components.workflow, {
+  ...approvalEvent,
+  workflowId,
+  value: { proposal: "A" },
+});
+```
+
+The result is a discriminated union on `result.name`, so once you check the
+name, TypeScript narrows `result.value` to that event's validator type (events
+without a validator give `unknown`). `result.id` holds the id of the winning
+event.
+
+#### Identifying the events in a race
+
+Each event in the race must be distinguishable, so they each need either a
+unique `name` or a unique `id`. If you don't need validators, plain `{ name }`
+objects work too:
+
+```ts
+const result = await step.raceEvents([{ name: "go" }, { name: "stop" }]);
+if (result.name === "go") {
+  // proceed
+}
+```
+
+To race over events you created ahead of time with `createEvent` (see
+[waiting for events by id](#waiting-for-dynamically-created-events-by-id)), pass
+their ids:
+
+```ts
+const result = await step.raceEvents([{ id: approvalId }, { id: rejectionId }]);
+// result.id is the id of whichever event fired first
+```
+
+Once a race resolves, consider every id you passed into it spent — don't await
+or race those ids again. Any events sent _after_ the winner are left untouched
+and stay available for a later `awaitEvent` or `raceEvents`.
+
+#### Timeout
+
+Without a timeout, a race waits indefinitely. Add a `timeout` (in milliseconds)
+to fail the step if no event arrives in time:
+
+```ts
+const result = await step.raceEvents(
+  [approvalEvent, rejectionEvent],
+  { timeout: 15 * 60 * 1000 }, // 15 minutes
+);
+```
+
+When the timeout fires, the step throws in your handler, which you can catch
+like any other step failure.
+
+#### Handling error events
+
+An event can carry an error instead of a value. The `failure` option controls
+what the race does with those:
+
+- **`"fail"` (default)** — the first event wins, value or error. An error event
+  makes the step throw.
+- **`"retry"`** — error events are ignored and the race keeps waiting for a
+  successful one. Pair this with a `timeout` so it can't wait forever.
+- **`"discard"`** — error events are consumed and the race keeps waiting on the
+  remaining events. If every event ends up erroring, the step fails.
+
+```ts
+const result = await step.raceEvents([approvalEvent, rejectionEvent], {
+  failure: "retry",
+  timeout: 60_000,
+});
+```
+
+You can also pass a `name` to label the step in your logs (it defaults to
+`"race(name1, name2, ...)"`).
+
+See [`example/convex/raceEvents.ts`](./example/convex/raceEvents.ts) for a
+complete example.
+
 ### Running nested workflows with `step.runWorkflow`
 
 Use `step.runWorkflow` to run another workflow as a single step in the current

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -15,6 +15,8 @@ import type * as example from "../example.js";
 import type * as nestedWorkflow from "../nestedWorkflow.js";
 import type * as oversized from "../oversized.js";
 import type * as passingSignals from "../passingSignals.js";
+import type * as raceEvents from "../raceEvents.js";
+import type * as raceTest from "../raceTest.js";
 import type * as test_contextRoundtrip from "../test/contextRoundtrip.js";
 import type * as test_inline from "../test/inline.js";
 import type * as test_oldSyntax from "../test/oldSyntax.js";
@@ -35,6 +37,8 @@ declare const fullApi: ApiFromModules<{
   nestedWorkflow: typeof nestedWorkflow;
   oversized: typeof oversized;
   passingSignals: typeof passingSignals;
+  raceEvents: typeof raceEvents;
+  raceTest: typeof raceTest;
   "test/contextRoundtrip": typeof test_contextRoundtrip;
   "test/inline": typeof test_inline;
   "test/oldSyntax": typeof test_oldSyntax;

--- a/example/convex/raceEvents.ts
+++ b/example/convex/raceEvents.ts
@@ -1,0 +1,128 @@
+import {
+  defineEvent,
+  vOnComplete,
+  vWorkflowId,
+  WorkflowManager,
+} from "@convex-dev/workflow";
+import { v } from "convex/values";
+import { components, internal } from "./_generated/api";
+import { internalMutation } from "./_generated/server";
+import { literals } from "convex-helpers/validators";
+
+const workflow = new WorkflowManager(components.workflow);
+
+const proposals = {
+  A: "Proposal A",
+  B: "Proposal B",
+  C: "Proposal C",
+};
+const vProposal = literals("A", "B", "C");
+export const approvalEvent = defineEvent({
+  name: "approval",
+  validator: v.object({ proposal: vProposal }),
+});
+export const rejectionEvent = defineEvent({
+  name: "rejection",
+  validator: v.object({ reason: v.string() }),
+});
+
+export const raceExample = workflow.define({
+  args: {},
+  returns: v.string(),
+  handler: async (step): Promise<string> => {
+    const result = await step.raceEvents([approvalEvent, rejectionEvent], {
+      name: "waitForDecision",
+      timeout: 15 * 60 * 1000, // 15 minutes
+    });
+
+    switch (result.name) {
+      case "approval": {
+        return `Approved. Selected: ${proposals[result.value.proposal]}`;
+      }
+      case "rejection": {
+        const val = result.value;
+        return `Rejected: ${val.reason}`;
+      }
+    }
+  },
+});
+
+export const sendApproval = internalMutation({
+  args: { workflowId: vWorkflowId, proposal: vProposal },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      ...approvalEvent,
+      workflowId: args.workflowId,
+      value: { proposal: args.proposal },
+    });
+  },
+});
+export const sendRejection = internalMutation({
+  args: { workflowId: vWorkflowId, reason: v.string() },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      ...rejectionEvent,
+      workflowId: args.workflowId,
+      value: { reason: args.reason },
+    });
+  },
+});
+
+export const startWorkflow = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const id = await workflow.start(
+      ctx,
+      internal.raceEvents.raceExample,
+      {},
+      {
+        context: {},
+        onComplete: internal.raceEvents.completeWorkflow,
+      },
+    );
+    await ctx.db.insert("flows", { workflowId: id, in: "", out: null });
+  },
+});
+export const completeWorkflow = internalMutation({
+  args: vOnComplete(v.any()),
+  handler: async (ctx, args): Promise<void> => {
+    const flow = await ctx.db
+      .query("flows")
+      .withIndex("workflowId", (q) => q.eq("workflowId", args.workflowId))
+      .first();
+    if (!flow) {
+      throw new Error(`Flow not found: ${args.workflowId}`);
+    }
+    await ctx.db.patch("flows", flow._id, { out: args.result });
+  },
+});
+
+export const raceWithoutValidators = workflow.define({
+  args: {},
+  returns: v.string(),
+  handler: async (step): Promise<string> => {
+    const result = await step.raceEvents([{ name: "go" }, { name: "stop" }]);
+    if (result.name === "go") {
+      return "Proceeding";
+    }
+    return "Stopped";
+  },
+});
+export const sendGo = internalMutation({
+  args: { workflowId: vWorkflowId },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      name: "go",
+      workflowId: args.workflowId,
+    });
+  },
+});
+export const sendStop = internalMutation({
+  args: { workflowId: vWorkflowId },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      name: "stop",
+      workflowId: args.workflowId,
+    });
+  },
+});

--- a/example/convex/raceTest.test.ts
+++ b/example/convex/raceTest.test.ts
@@ -1,0 +1,229 @@
+/// <reference types="vite/client" />
+
+import { expect, describe, test, vi, beforeEach, afterEach } from "vitest";
+import { initConvexTest } from "./setup.test";
+import { components, internal } from "./_generated/api";
+import { workflow } from "./raceTest";
+import { getStatus } from "@convex-dev/workflow";
+import { assert } from "convex-helpers";
+
+describe("raceEvents", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("basic race", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.run((ctx) =>
+      workflow.start(ctx, internal.raceTest.basicRace, {}),
+    );
+    await t.mutation(internal.raceTest.sendEventA, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const status = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(status.type).toBe("completed");
+    assert(status.type === "completed");
+    expect(status.result).toBe("eventA");
+  });
+
+  test("multiple pre-existing events - earliest-sent wins", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.run((ctx) =>
+      workflow.start(ctx, internal.raceTest.raceWithExtraStep, {}),
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    await t.mutation(internal.raceTest.sendEventB, { workflowId });
+    await t.mutation(internal.raceTest.sendEventA, { workflowId });
+    await t.mutation(internal.raceTest.sendBlock, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const status = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(status.type).toBe("completed");
+    assert(status.type === "completed");
+    expect(status.result).toBe("eventB");
+  });
+
+  test("timeout triggers failure", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.run((ctx) =>
+      workflow.start(ctx, internal.raceTest.raceWithTimeout, { timeout: 1000 }),
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const status = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(status.type).toBe("failed");
+    assert(status.type === "failed");
+    expect(status.error).toContain("Timeout");
+  });
+
+  test("event arrives before timeout", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.run((ctx) =>
+      workflow.start(ctx, internal.raceTest.raceWithTimeout, {
+        timeout: 60000,
+      }),
+    );
+    await t.mutation(internal.raceTest.sendEventA, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const status = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(status.type).toBe("completed");
+    assert(status.type === "completed");
+    expect(status.result).toBe("eventA");
+  });
+
+  test("validators parse correctly", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.run((ctx) =>
+      workflow.start(ctx, internal.raceTest.raceWithValidators, {}),
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    await t.mutation(internal.raceTest.sendApproval, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const status = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(status.type).toBe("completed");
+    assert(status.type === "completed");
+    expect(status.result).toEqual({
+      id: expect.any(String),
+      name: "approval",
+      value: { proposal: "A" },
+    });
+  });
+
+  test("race over events referenced by id", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.run((ctx) =>
+      workflow.start(ctx, internal.raceTest.raceById, {}),
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    // The pre-created events were transitioned to "waiting"; sending one by
+    // name resolves the race and returns its id.
+    await t.mutation(internal.raceTest.sendNamed, {
+      workflowId,
+      name: "byIdB",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const status = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(status.type).toBe("completed");
+    assert(status.type === "completed");
+    expect(status.result).toEqual({
+      id: expect.any(String),
+      name: "byIdB",
+    });
+  });
+});
+
+describe("failure modes", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("failure mode fail - failure propagates", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.run((ctx) =>
+      workflow.start(ctx, internal.raceTest.raceWithFailureFail, {}),
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    await t.mutation(internal.raceTest.sendFailedEventA, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const status = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(status.type).toBe("failed");
+    assert(status.type === "failed");
+    expect(status.error).toContain("intentional failure");
+  });
+
+  test("failure mode fail - success event wins immediately", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.run((ctx) =>
+      workflow.start(ctx, internal.raceTest.raceWithFailureFail, {}),
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    await t.mutation(internal.raceTest.sendEventA, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const status = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(status.type).toBe("completed");
+    assert(status.type === "completed");
+    expect(status.result).toBe("eventA");
+  });
+
+  test("failure mode retry - retries on failure", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.run((ctx) =>
+      workflow.start(ctx, internal.raceTest.raceWithFailureRetry, {}),
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    await t.mutation(internal.raceTest.sendFailedEventA, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const status = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(status.type).toBe("inProgress");
+    await t.mutation(internal.raceTest.sendEventA, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const statusAfter = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(statusAfter.type).toBe("completed");
+    assert(statusAfter.type === "completed");
+    expect(statusAfter.result).toBe("eventA");
+  });
+
+  test("failure mode discard - ignores failures", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.run((ctx) =>
+      workflow.start(ctx, internal.raceTest.raceWithFailureDiscard, {}),
+    );
+    await t.mutation(internal.raceTest.sendFailedEventB, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    await t.mutation(internal.raceTest.sendEventB, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const statusBefore = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(statusBefore.type).toBe("inProgress");
+    await t.mutation(internal.raceTest.sendEventA, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const statusAfter = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(statusAfter.type).toBe("completed");
+    assert(statusAfter.type === "completed");
+    expect(statusAfter.result).toBe("eventA");
+  });
+
+  test("failure mode discard - exhausted all events", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.run((ctx) =>
+      workflow.start(ctx, internal.raceTest.raceWithFailureDiscard, {}),
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    await t.mutation(internal.raceTest.sendFailedEventA, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    await t.mutation(internal.raceTest.sendFailedEventB, { workflowId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const status = await t.run((ctx) =>
+      getStatus(ctx, components.workflow, workflowId),
+    );
+    expect(status.type).toBe("failed");
+    assert(status.type === "failed");
+    expect(status.error).toContain("Exhausted all events");
+  });
+});

--- a/example/convex/raceTest.ts
+++ b/example/convex/raceTest.ts
@@ -1,0 +1,252 @@
+import {
+  createEvent,
+  defineEvent,
+  vEventId,
+  vWorkflowId,
+  WorkflowManager,
+  type EventId,
+} from "@convex-dev/workflow";
+import { v } from "convex/values";
+import { components, internal } from "./_generated/api.js";
+import { internalMutation } from "./_generated/server.js";
+
+export const workflow = new WorkflowManager(components.workflow);
+
+export const basicRace = workflow.define({
+  args: {},
+  returns: v.string(),
+  handler: async (step): Promise<string> => {
+    const result = await step.raceEvents([
+      { name: "eventA" },
+      { name: "eventB" },
+    ]);
+    return result.name;
+  },
+});
+
+export const raceWithExtraStep = workflow.define({
+  args: {},
+  returns: v.string(),
+  handler: async (step): Promise<string> => {
+    await step.awaitEvent({ name: "block" });
+    const result = await step.raceEvents([
+      { name: "eventA" },
+      { name: "eventB" },
+    ]);
+    return result.name;
+  },
+});
+
+export const sendEventA = internalMutation({
+  args: { workflowId: vWorkflowId },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      name: "eventA",
+      workflowId: args.workflowId,
+    });
+  },
+});
+
+export const sendEventB = internalMutation({
+  args: { workflowId: vWorkflowId },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      name: "eventB",
+      workflowId: args.workflowId,
+    });
+  },
+});
+
+export const sendBlock = internalMutation({
+  args: { workflowId: vWorkflowId },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      name: "block",
+      workflowId: args.workflowId,
+    });
+  },
+});
+
+export const raceWithTimeout = workflow.define({
+  args: { timeout: v.number() },
+  returns: v.string(),
+  handler: async (step, args): Promise<string> => {
+    const result = await step.raceEvents(
+      [{ name: "eventA" }, { name: "eventB" }],
+      {
+        timeout: args.timeout,
+      },
+    );
+    return result.name;
+  },
+});
+
+export const raceWithFailureFail = workflow.define({
+  args: {},
+  returns: v.string(),
+  handler: async (step): Promise<string> => {
+    const result = await step.raceEvents(
+      [{ name: "eventA" }, { name: "eventB" }],
+      {
+        failure: "fail",
+      },
+    );
+    return result.name;
+  },
+});
+
+export const raceWithFailureRetry = workflow.define({
+  args: {},
+  returns: v.string(),
+  handler: async (step): Promise<string> => {
+    const result = await step.raceEvents(
+      [{ name: "eventA" }, { name: "eventB" }],
+      {
+        failure: "retry",
+      },
+    );
+    return result.name;
+  },
+});
+
+export const raceWithFailureDiscard = workflow.define({
+  args: {},
+  returns: v.string(),
+  handler: async (step): Promise<string> => {
+    const result = await step.raceEvents(
+      [{ name: "eventA" }, { name: "eventB" }],
+      {
+        failure: "discard",
+      },
+    );
+    return result.name;
+  },
+});
+
+export const sendFailedEventA = internalMutation({
+  args: { workflowId: vWorkflowId },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      name: "eventA",
+      workflowId: args.workflowId,
+      error: "intentional failure",
+    });
+  },
+});
+
+export const sendFailedEventB = internalMutation({
+  args: { workflowId: vWorkflowId },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      name: "eventB",
+      workflowId: args.workflowId,
+      error: "intentional failure",
+    });
+  },
+});
+
+export const raceWithValidators = workflow.define({
+  args: {},
+  returns: v.any(),
+  handler: async (step) => {
+    const approvalEvent = defineEvent({
+      name: "approval",
+      validator: v.object({ proposal: v.string() }),
+    });
+    const rejectionEvent = defineEvent({
+      name: "rejection",
+      validator: v.object({ reason: v.string() }),
+    });
+    const result = await step.raceEvents([approvalEvent, rejectionEvent]);
+    return result;
+  },
+});
+
+export const sendApproval = internalMutation({
+  args: { workflowId: vWorkflowId },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      name: "approval",
+      workflowId: args.workflowId,
+      value: { proposal: "A" },
+    });
+  },
+});
+
+export const sendRejection = internalMutation({
+  args: { workflowId: vWorkflowId },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      name: "rejection",
+      workflowId: args.workflowId,
+      value: { reason: "not needed" },
+    });
+  },
+});
+
+export const raceGoStop = workflow.define({
+  args: {},
+  returns: v.string(),
+  handler: async (step): Promise<string> => {
+    const result = await step.raceEvents([{ name: "go" }, { name: "stop" }]);
+    return result.name;
+  },
+});
+
+// Race over events referenced by id (pre-created with `createEvent`), the same
+// way `awaitEvent` accepts an id.
+export const raceById = workflow.define({
+  args: {},
+  returns: v.object({ id: vEventId(), name: v.string() }),
+  handler: async (step): Promise<{ id: EventId; name: string }> => {
+    const idA = await step.runMutation(internal.raceTest.createRaceEvent, {
+      workflowId: step.workflowId,
+      name: "byIdA",
+    });
+    const idB = await step.runMutation(internal.raceTest.createRaceEvent, {
+      workflowId: step.workflowId,
+      name: "byIdB",
+    });
+    const result = await step.raceEvents([{ id: idA }, { id: idB }]);
+    return { id: result.id, name: result.name };
+  },
+});
+
+export const createRaceEvent = internalMutation({
+  args: { workflowId: vWorkflowId, name: v.string() },
+  handler: async (ctx, args): Promise<EventId> =>
+    createEvent(ctx, components.workflow, {
+      name: args.name,
+      workflowId: args.workflowId,
+    }),
+});
+
+export const sendNamed = internalMutation({
+  args: { workflowId: vWorkflowId, name: v.string() },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      name: args.name,
+      workflowId: args.workflowId,
+    });
+  },
+});
+
+export const sendGo = internalMutation({
+  args: { workflowId: vWorkflowId },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      name: "go",
+      workflowId: args.workflowId,
+    });
+  },
+});
+
+export const sendStop = internalMutation({
+  args: { workflowId: vWorkflowId },
+  handler: async (ctx, args) => {
+    await workflow.sendEvent(ctx, {
+      name: "stop",
+      workflowId: args.workflowId,
+    });
+  },
+});

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -37,10 +37,12 @@ export {
   vEventId,
   vWorkflowId,
   vWorkflowStep,
+  vOnComplete,
   type EventId,
   type WorkflowId,
   type WorkflowStep,
 } from "../types.js";
+export type { RaceResult } from "./workflowContext.js";
 export type { RunOptions, WorkflowCtx } from "./workflowContext.js";
 export type { WorkflowArgs } from "./workflowMutation.js";
 export { vResultValidator } from "@convex-dev/workpool";

--- a/src/client/step.ts
+++ b/src/client/step.ts
@@ -22,6 +22,7 @@ import type {
 import { MAX_JOURNAL_SIZE, formatErrorWithStack } from "../shared.js";
 import type { EventId, SchedulerOptions } from "../types.js";
 import { pick } from "convex-helpers";
+import type { EventNameOrId } from "./workflowContext.js";
 
 export type WorkerResult =
   | { type: "handlerDone"; runResult: RunResult }
@@ -48,6 +49,14 @@ export type StepRequest = {
     | {
         kind: "sleep";
         args: Record<string, never>;
+      }
+    | {
+        kind: "race";
+        args: {
+          events: Array<EventNameOrId>;
+          timeout?: number;
+          failure?: "fail" | "retry" | "discard";
+        };
       };
   retry: RetryBehavior | boolean | undefined;
   inline: boolean;
@@ -233,6 +242,18 @@ export class StepExecutor {
             step = {
               kind: "sleep" as const,
               ...commonFields,
+            };
+            break;
+          case "race":
+            step = {
+              kind: "race" as const,
+              timeout:
+                target.args.timeout !== undefined
+                  ? { ms: target.args.timeout }
+                  : undefined,
+              failure: target.args.failure,
+              ...commonFields,
+              args: target.args,
             };
             break;
           default:

--- a/src/client/workflowContext.ts
+++ b/src/client/workflowContext.ts
@@ -14,6 +14,28 @@ import type { EventId, SchedulerOptions, WorkflowId } from "../types.js";
 import { safeFunctionName } from "./safeFunctionName.js";
 import type { StepRequest } from "./step.js";
 import type { TransactionLimits } from "./types.js";
+import { assert } from "convex-helpers";
+
+export type EventNameOrId =
+  | { name?: string; id: EventId }
+  | { id?: EventId; name: string };
+
+export type RaceResult<
+  T extends ReadonlyArray<
+    EventNameOrId & {
+      validator?: Validator<any, any, any>;
+    }
+  >,
+> = {
+  [K in keyof T]: T[K] extends {
+    name: infer N extends string;
+    validator: Validator<infer V, any, any>;
+  }
+    ? { id: EventId; name: N; value: V }
+    : T[K] extends { name: infer N extends string }
+      ? { id: EventId; name: N; value: unknown }
+      : { id: EventId; name: string; value: unknown };
+}[number];
 
 export type RunOptions = {
   /**
@@ -134,6 +156,34 @@ export type WorkflowCtx = {
    * @param opts - Optionally name the step. Default: "sleep"
    */
   sleep(duration: number, opts?: { name?: string }): Promise<void>;
+
+  /**
+   * Waits for any one of multiple events, returning the first that fires.
+   *
+   * Each event in the array must have a unique name. The workflow blocks
+   * until an event with one of the given names is sent, then returns the
+   * matched event's name and value.
+   *
+   * @param events - Array of event definitions, each with a unique `name`
+   *   and an optional `validator` to parse the event's payload.
+   * @param opts - Optional options, including a custom step `name` for
+   *   observability (defaults to `"race(name1, name2, ...)"`) and a
+   *   `timeout` in milliseconds after which the race rejects with an error.
+   */
+  raceEvents<
+    const T extends ReadonlyArray<
+      EventNameOrId & {
+        validator?: Validator<any, any, any>;
+      }
+    >,
+  >(
+    events: T,
+    opts?: {
+      name?: string;
+      timeout?: number;
+      failure?: "fail" | "retry" | "discard";
+    },
+  ): Promise<RaceResult<T>>;
 };
 
 export function createWorkflowCtx(
@@ -203,6 +253,66 @@ export function createWorkflowCtx(
         return parse(event.validator, result);
       }
       return result as any;
+    },
+
+    raceEvents: async <
+      T extends ReadonlyArray<
+        EventNameOrId & {
+          validator?: Validator<any, any, any>;
+        }
+      >,
+    >(
+      events: T,
+      opts?: {
+        name?: string;
+        timeout?: number;
+        failure?: "fail" | "retry" | "discard";
+      },
+    ) => {
+      assert(events.length > 0, "At least one event must be specified.");
+      assert(
+        new Set(events.map((e) => e.id ?? e.name)).size === events.length,
+        "All events must have a unique name or id.",
+      );
+      assert(
+        opts?.timeout === undefined ||
+          (opts.timeout > 0 && Number.isFinite(opts.timeout)),
+        "Timeout must be a positive number.",
+      );
+      assert(
+        events.every((e) => e.id || e.name),
+        "All events must have an ID or a name.",
+      );
+      const result = await run(sender, {
+        name:
+          opts?.name ?? `race(${events.map((e) => e.name ?? e.id).join(", ")})`,
+        target: {
+          kind: "race",
+          args: {
+            events: events.map(({ validator: _validator, ...rest }) => rest),
+            timeout: opts?.timeout,
+            failure: opts?.failure,
+          },
+        },
+        retry: undefined,
+        inline: false,
+        unstableArgs: false,
+        schedulerOptions: {},
+        transactionLimits: undefined,
+      });
+      const eventId = (result as any).eventId as EventId;
+      const eventName = (result as any).eventName as string;
+      const rawValue = (result as any).value;
+      // Prefer matching the winning spec by id (events raced by id may not
+      // carry a name), falling back to the event's name.
+      const winner =
+        events.find((e) => e.id !== undefined && e.id === eventId) ??
+        events.find((e) => e.name === eventName);
+      return {
+        id: eventId,
+        name: eventName,
+        value: winner?.validator ? parse(winner.validator, rawValue) : rawValue,
+      } as RaceResult<T>;
     },
   } satisfies WorkflowCtx;
 }

--- a/src/component/_generated/api.ts
+++ b/src/component/_generated/api.ts
@@ -14,6 +14,7 @@ import type * as logging from "../logging.js";
 import type * as model from "../model.js";
 import type * as oversizedValues from "../oversizedValues.js";
 import type * as pool from "../pool.js";
+import type * as race from "../race.js";
 import type * as utils from "../utils.js";
 import type * as workflow from "../workflow.js";
 
@@ -31,6 +32,7 @@ const fullApi: ApiFromModules<{
   model: typeof model;
   oversizedValues: typeof oversizedValues;
   pool: typeof pool;
+  race: typeof race;
   utils: typeof utils;
   workflow: typeof workflow;
 }> = anyApi as any;

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -126,6 +126,23 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | { kind: "canceled" };
                   startedAt: number;
                   workId?: string;
+                }
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  events?: Array<{ id: string; name: string }>;
+                  failure?: "fail" | "retry" | "discard";
+                  inProgress: boolean;
+                  kind: "race";
+                  name: string;
+                  raceWinnerEventId?: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                  timeout?: { ms: number; workId?: string };
                 };
             stepNumber: number;
             workflowId: string;
@@ -220,6 +237,23 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | { kind: "canceled" };
                   startedAt: number;
                   workId?: string;
+                }
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  events?: Array<{ id: string; name: string }>;
+                  failure?: "fail" | "retry" | "discard";
+                  inProgress: boolean;
+                  kind: "race";
+                  name: string;
+                  raceWinnerEventId?: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                  timeout?: { ms: number; workId?: string };
                 };
           }>;
           workflowId: string;
@@ -296,6 +330,23 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                   | { kind: "canceled" };
                 startedAt: number;
                 workId?: string;
+              }
+            | {
+                args: any;
+                argsSize: number;
+                completedAt?: number;
+                events?: Array<{ id: string; name: string }>;
+                failure?: "fail" | "retry" | "discard";
+                inProgress: boolean;
+                kind: "race";
+                name: string;
+                raceWinnerEventId?: string;
+                runResult?:
+                  | { kind: "success"; returnValue: any }
+                  | { error: string; kind: "failed" }
+                  | { kind: "canceled" };
+                startedAt: number;
+                timeout?: { ms: number; workId?: string };
               };
           stepNumber: number;
           workflowId: string;
@@ -414,6 +465,23 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | { kind: "canceled" };
                   startedAt: number;
                   workId?: string;
+                }
+              | {
+                  args: any;
+                  argsSize: number;
+                  completedAt?: number;
+                  events?: Array<{ id: string; name: string }>;
+                  failure?: "fail" | "retry" | "discard";
+                  inProgress: boolean;
+                  kind: "race";
+                  name: string;
+                  raceWinnerEventId?: string;
+                  runResult?:
+                    | { kind: "success"; returnValue: any }
+                    | { error: string; kind: "failed" }
+                    | { kind: "canceled" };
+                  startedAt: number;
+                  timeout?: { ms: number; workId?: string };
                 };
             stepNumber: number;
             workflowId: string;
@@ -525,9 +593,11 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             args: any;
             completedAt?: number;
             eventId?: string;
-            kind: "function" | "workflow" | "event" | "sleep";
+            events?: Array<{ id: string; name: string }>;
+            kind: "function" | "workflow" | "event" | "sleep" | "race";
             name: string;
             nestedWorkflowId?: string;
+            raceWinnerEventId?: string;
             runResult?:
               | { kind: "success"; returnValue: any }
               | { error: string; kind: "failed" }

--- a/src/component/event.ts
+++ b/src/component/event.ts
@@ -121,16 +121,15 @@ export const send = mutation({
       ["waiting", "created"],
     );
     const { workflowId } = event;
-    const name = args.name ?? event.name;
     switch (event.state.kind) {
       case "sent": {
         throw new Error(
-          `Event already sent: ${event._id} (${name}) in workflow ${workflowId}`,
+          `Event already sent: ${event._id} (${event.name}) in workflow ${workflowId}`,
         );
       }
       case "consumed": {
         throw new Error(
-          `Event already consumed: ${event._id} (${name}) in workflow ${workflowId}`,
+          `Event already consumed: ${event._id} (${event.name}) in workflow ${workflowId}`,
         );
       }
       case "created": {
@@ -143,31 +142,126 @@ export const send = mutation({
         const step = await ctx.db.get("steps", event.state.stepId);
         assert(
           step,
-          `Entry ${event.state.stepId} not found when sending event ${event._id} (${name}) in workflow ${workflowId}`,
+          `Entry ${event.state.stepId} not found when sending event ${event._id} (${event.name}) in workflow ${workflowId}`,
         );
-        assert(step.step.kind === "event", "Step is not an event");
-        step.step.eventId = event._id;
-        step.step.runResult = checkForOversizedResult(args.result);
-        step.step.inProgress = false;
-        step.step.completedAt = Date.now();
-        await ctx.db.replace("steps", step._id, step);
-        await ctx.db.patch("events", event._id, {
-          state: {
-            kind: "consumed",
-            stepId: step._id,
-            waitingAt: event.state.waitingAt,
-            sentAt: Date.now(),
-            consumedAt: Date.now(),
-          },
-        });
-        const anyMoreEvents = await ctx.db
-          .query("events")
-          .withIndex("workflowId_state", (q) =>
-            q.eq("workflowId", workflowId).eq("state.kind", "waiting"),
-          )
-          .order("desc")
-          .first();
-        if (!anyMoreEvents) {
+        assert(
+          step.step.kind === "event" || step.step.kind === "race",
+          "Step is not an event",
+        );
+        if (step.step.kind === "event") {
+          step.step.eventId = event._id;
+          step.step.runResult = checkForOversizedResult(args.result);
+          step.step.inProgress = false;
+          step.step.completedAt = Date.now();
+          await ctx.db.replace("steps", step._id, step);
+          await ctx.db.patch("events", event._id, {
+            state: {
+              kind: "consumed",
+              stepId: step._id,
+              waitingAt: event.state.waitingAt,
+              sentAt: Date.now(),
+              consumedAt: Date.now(),
+            },
+          });
+          const anyMoreEvents = await ctx.db
+            .query("events")
+            .withIndex("workflowId_state", (q) =>
+              q.eq("workflowId", workflowId).eq("state.kind", "waiting"),
+            )
+            .order("desc")
+            .first();
+          if (!anyMoreEvents) {
+            const workflow = await ctx.db.get("workflows", workflowId);
+            assert(workflow, `Workflow ${workflowId} not found`);
+            const workpool = await getWorkpool(ctx, args.workpoolOptions);
+            await enqueueWorkflow(ctx, workflow, workpool);
+          }
+        } else {
+          if (args.result.kind !== "success" && step.step.failure === "retry") {
+            break;
+          }
+          const now = Date.now();
+          await ctx.db.patch("events", event._id, {
+            state: {
+              kind: "consumed",
+              stepId: step._id,
+              waitingAt: event.state.waitingAt,
+              sentAt: now,
+              consumedAt: now,
+            },
+          });
+          const losingEvents = await ctx.db
+            .query("events")
+            .withIndex("workflowId_state", (q) =>
+              q.eq("workflowId", workflowId).eq("state.kind", "waiting"),
+            )
+            .filter((q) => q.eq(q.field("state.stepId"), step._id))
+            .collect();
+          // until all events are exhausted continue waiting
+          if (
+            args.result.kind !== "success" &&
+            step.step.failure === "discard" &&
+            losingEvents.length > 0
+          ) {
+            break;
+          }
+          if (step.step.timeout?.workId) {
+            const workpool = await getWorkpool(ctx, {});
+            await workpool.cancel(ctx, step.step.timeout.workId);
+          }
+          if (args.result.kind === "success") {
+            step.step.raceWinnerEventId = event._id;
+            step.step.runResult = checkForOversizedResult({
+              kind: "success",
+              returnValue: {
+                eventName: event.name,
+                eventId: event._id,
+                value: args.result.returnValue,
+              },
+            });
+          } else {
+            switch (step.step.failure) {
+              case "discard": {
+                step.step.runResult = {
+                  kind: "failed",
+                  error: "Exhausted all events",
+                };
+                break;
+              }
+              case "retry": {
+                throw new Error("unreachable: retry failure");
+              }
+              case "fail":
+              case undefined: {
+                step.step.raceWinnerEventId = event._id;
+                step.step.runResult = {
+                  kind: "failed",
+                  error: args.result.kind === "failed" ? args.result.error : "Canceled",
+                };
+                break;
+              }
+            }
+          }
+          step.step.inProgress = false;
+          step.step.completedAt = now;
+          await Promise.all([
+            ctx.db.replace("steps", step._id, step),
+            ...losingEvents.map((losing) => {
+              assert(
+                losing.state.kind === "waiting",
+                `Losing event ${losing._id} is not waiting`,
+              );
+              return ctx.db.patch("events", losing._id, {
+                state: {
+                  kind: "consumed",
+                  stepId: step._id,
+                  waitingAt: losing.state.waitingAt,
+                  sentAt: now,
+                  consumedAt: now,
+                },
+              });
+            }),
+          ]);
           const workflow = await ctx.db.get("workflows", workflowId);
           assert(workflow, `Workflow ${workflowId} not found`);
           const workpool = await getWorkpool(ctx, args.workpoolOptions);

--- a/src/component/journal.ts
+++ b/src/component/journal.ts
@@ -1,5 +1,5 @@
 import { getConvexSize, v } from "convex/values";
-import { mutation, query } from "./_generated/server.js";
+import { mutation, query, type MutationCtx } from "./_generated/server.js";
 import {
   journalDocument,
   type JournalEntry,
@@ -21,6 +21,43 @@ import { assert } from "convex-helpers";
 import { MAX_JOURNAL_SIZE } from "../shared.js";
 import { awaitEvent } from "./event.js";
 import { createHandler } from "./workflow.js";
+import type { Doc, Id } from "./_generated/dataModel.js";
+
+type EventNameOrId =
+  | {
+      id: Id<"events">;
+      name?: string;
+    }
+  | {
+      id?: Id<"events">;
+      name: string;
+    };
+
+type SentEvent = Doc<"events"> & {
+  state: { kind: "sent" };
+};
+
+async function sentEvents(
+  ctx: MutationCtx,
+  workflowId: Doc<"workflows">["_id"],
+  events: Array<EventNameOrId>,
+) {
+  return (
+    (await ctx.db
+      .query("events")
+      .withIndex("workflowId_state", (q) =>
+        q.eq("workflowId", workflowId).eq("state.kind", "sent"),
+      )
+      .filter((q) =>
+        q.or(
+          ...events.map((e) =>
+            e.id ? q.eq(q.field("_id"), e.id) : q.eq(q.field("name"), e.name),
+          ),
+        ),
+      )
+      .collect()) as SentEvent[]
+  ).sort((a, b) => a.state.sentAt - b.state.sentAt);
+}
 
 export const load = query({
   args: {
@@ -181,6 +218,200 @@ export const startSteps = mutation({
             {},
             { context, onComplete, name, ...schedulerOptions },
           );
+        } else if (step.kind === "race") {
+          const raceId = entry._id;
+          const events = step.args.events as EventNameOrId[];
+          const now = Date.now();
+
+          const idSet = new Set<string>();
+          const idEvents = new Map<string, Doc<"events">>();
+          for (const spec of events) {
+            if (!spec.id) continue;
+            idSet.add(spec.id);
+            const existing = await ctx.db.get("events", spec.id);
+            assert(
+              existing,
+              `Event not found: ${spec.id} in workflow ${workflow._id}`,
+            );
+            assert(
+              existing.workflowId === workflow._id,
+              `Event ${spec.id} (${existing.name}) does not belong to workflow ${workflow._id}`,
+            );
+            if (existing.state.kind === "waiting") {
+              throw new Error(
+                `Event already waiting: ${spec.id} (${existing.name}) in workflow ${workflow._id}`,
+              );
+            }
+            if (existing.state.kind === "consumed") {
+              throw new Error(
+                `Event already consumed: ${spec.id} (${existing.name}) in workflow ${workflow._id}`,
+              );
+            }
+            idEvents.set(spec.id, existing);
+          }
+
+          const sent = await sentEvents(ctx, workflow._id, events);
+
+          const keyOf = (s: SentEvent) => (idSet.has(s._id) ? s._id : s.name);
+          const eventsToWait = new Set(events.map((e) => (e.id ?? e.name)!));
+          let eventsToConsume: Doc<"events">[] = [];
+          let winner: SentEvent | undefined;
+          switch (step.failure) {
+            case "discard": {
+              const toConsume = new Map<string, SentEvent>();
+              for (const s of sent) {
+                const key = keyOf(s);
+                if (toConsume.has(key)) {
+                  continue;
+                }
+                toConsume.set(key, s);
+                eventsToWait.delete(key);
+                if (s.state.result.kind === "success") {
+                  winner = s;
+                  break;
+                }
+              }
+              eventsToConsume = Array.from(toConsume.values());
+              break;
+            }
+            case "retry": {
+              const winnerIndex = sent.findIndex(
+                (s) => s.state.result.kind === "success",
+              );
+              if (winnerIndex >= 0) {
+                winner = sent[winnerIndex];
+                eventsToConsume = sent.slice(0, winnerIndex + 1);
+              } else {
+                eventsToConsume = sent;
+              }
+              break;
+            }
+            case "fail":
+            case undefined:
+            default: {
+              if (sent.length > 0) {
+                winner = sent[0];
+                eventsToWait.delete(keyOf(winner));
+                eventsToConsume.push(winner);
+              }
+              break;
+            }
+          }
+
+          if (eventsToWait.size === 0 || winner) {
+            if (winner) {
+              step.raceWinnerEventId = winner._id;
+              step.runResult =
+                winner.state.result.kind === "success"
+                  ? {
+                      kind: "success",
+                      returnValue: {
+                        eventName: winner.name,
+                        eventId: winner._id,
+                        value: winner.state.result.returnValue,
+                      },
+                    }
+                  : {
+                      kind: "failed",
+                      error: winner.state.result.kind === "failed" ? winner.state.result.error : "Canceled",
+                    };
+              eventsToWait.clear();
+            } else {
+              step.runResult = {
+                kind: "failed",
+                error: "Exhausted all events",
+              };
+            }
+            entry.step.inProgress = false;
+            entry.step.completedAt = Date.now();
+            console.event("stepCompleted", {
+              workflowId: entry.workflowId,
+              workflowName: workflow.name,
+              status: entry.step.runResult!.kind,
+              stepName: entry.step.name,
+              stepNumber,
+            });
+          }
+
+          if (step.timeout && entry.step.inProgress) {
+            const workId = await workpool.enqueueMutation(
+              ctx,
+              internal.race.timeout,
+              {
+                stepId: raceId,
+                workpoolOptions: args.workpoolOptions,
+                generationNumber,
+              },
+              {
+                runAfter: step.timeout.ms,
+              },
+            );
+            step.timeout.workId = workId;
+          }
+
+          // NOTE: This is what makes the retry + by-id case work:
+          // a pre-sent id-event that failed must not be consumed,
+          // so it can be re-patched back to waiting,
+          // you can't recreate an event with the same id,
+          // unlike name-based retry which just inserts a fresh waiting doc.
+          eventsToConsume = eventsToConsume.filter(
+            (e) => !eventsToWait.has(e._id),
+          );
+
+          if (!entry.step.inProgress) {
+            const idCreated = Array.from(idEvents.values()).filter(
+              (e) => e.state.kind === "created",
+            );
+            eventsToConsume.push(...idCreated);
+            eventsToWait.clear();
+          }
+
+          const [, waitingIds] = await Promise.all([
+            Promise.all(
+              eventsToConsume.map((e) =>
+                ctx.db.patch("events", e._id, {
+                  state: {
+                    kind: "consumed",
+                    stepId: raceId,
+                    sentAt: e.state.kind === "sent" ? e.state.sentAt : now,
+                    waitingAt:
+                      e.state.kind === "waiting" ? e.state.waitingAt : now,
+                    consumedAt: now,
+                  },
+                }),
+              ),
+            ),
+            Promise.all(
+              Array.from(eventsToWait.values()).map(async (key) => {
+                if (idSet.has(key)) {
+                  const id = key as Id<"events">;
+                  await ctx.db.patch("events", id, {
+                    state: {
+                      kind: "waiting",
+                      waitingAt: now,
+                      stepId: raceId,
+                    },
+                  });
+                  return { id, name: idEvents.get(key)!.name };
+                }
+                const id = await ctx.db.insert("events", {
+                  workflowId: workflow._id,
+                  name: key,
+                  state: {
+                    kind: "waiting",
+                    waitingAt: now,
+                    stepId: raceId,
+                  },
+                });
+                return { id, name: key };
+              }),
+            ),
+          ]);
+
+          step.events = [
+            ...eventsToConsume.map((e) => ({ id: e._id, name: e.name })),
+            ...waitingIds,
+          ];
         } else {
           const context: OnCompleteContext = {
             generationNumber,

--- a/src/component/race.ts
+++ b/src/component/race.ts
@@ -1,0 +1,71 @@
+import { v } from "convex/values";
+import { internalMutation, type MutationCtx } from "./_generated/server.js";
+import { assert } from "convex-helpers";
+import { enqueueWorkflow, getWorkpool, workpoolOptions } from "./pool.js";
+import { getDefaultLogger } from "./utils.js";
+import type { Doc } from "./_generated/dataModel.js";
+
+export const timeout = internalMutation({
+  args: {
+    stepId: v.id("steps"),
+    workpoolOptions: workpoolOptions,
+    generationNumber: v.number(),
+  },
+  async handler(ctx, args) {
+    const console = await getDefaultLogger(ctx);
+    const step = await ctx.db.get("steps", args.stepId);
+    assert(step, `Step not found: ${args.stepId}`);
+    assert(step.step.kind === "race", `Step is not a race: ${args.stepId}`);
+    if (!step.step.inProgress) {
+      console.error(`Step ${args.stepId} is not in progress`);
+      return;
+    }
+    const workflow = await ctx.db.get("workflows", step.workflowId);
+    assert(workflow, `Workflow ${step.workflowId} not found`);
+    if (workflow.generationNumber !== args.generationNumber) {
+      console.error(
+        `Workflow: ${step.workflowId} already has generation number ${workflow.generationNumber} when completing ${args.stepId}. Expected ${args.generationNumber}`,
+      );
+      return;
+    }
+
+    step.step.runResult = { kind: "failed", error: "Timeout" };
+    await consumeRaceEvents(ctx, step);
+    step.step.inProgress = false;
+    step.step.completedAt = Date.now();
+    await ctx.db.replace("steps", step._id, step);
+
+    const workpool = await getWorkpool(ctx, args.workpoolOptions);
+    await enqueueWorkflow(ctx, workflow, workpool);
+  },
+});
+
+export async function consumeRaceEvents(ctx: MutationCtx, step: Doc<"steps">) {
+  assert(step.step.kind === "race", `Step is not a race: ${step._id}`);
+  assert(step.step.inProgress, `Step ${step._id} is not in progress`);
+  const raceEvents = await ctx.db
+    .query("events")
+    .withIndex("workflowId_state", (q) =>
+      q.eq("workflowId", step.workflowId).eq("state.kind", "waiting"),
+    )
+    .filter((q) => q.eq(q.field("state.stepId"), step._id))
+    .collect();
+  const consumedAt = Date.now();
+  await Promise.all(
+    raceEvents.map((event) => {
+      assert(
+        event.state.kind === "waiting",
+        `Race event ${event._id} is not waiting`,
+      );
+      return ctx.db.patch("events", event._id, {
+        state: {
+          kind: "consumed",
+          stepId: step._id,
+          waitingAt: event.state.waitingAt,
+          sentAt: consumedAt,
+          consumedAt,
+        },
+      });
+    }),
+  );
+}

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -66,6 +66,23 @@ export const step = v.union(
     workId: v.optional(vWorkIdValidator),
     ...stepCommonFields,
   }),
+  v.object({
+    kind: v.literal("race"),
+    ...stepCommonFields,
+    events: v.optional(
+      v.array(
+        v.object({
+          id: v.id("events"),
+          name: v.string(),
+        }),
+      ),
+    ),
+    timeout: v.optional(
+      v.object({ ms: v.number(), workId: v.optional(vWorkIdValidator) }),
+    ),
+    failure: v.optional(literals("fail", "retry", "discard")),
+    raceWinnerEventId: v.optional(v.id("events")),
+  }),
 );
 export type Step = Infer<typeof step>;
 

--- a/src/component/workflow.test.ts
+++ b/src/component/workflow.test.ts
@@ -6,6 +6,7 @@ import { initConvexTest } from "./setup.test.js";
 import type { Id } from "./_generated/dataModel.js";
 import { internalMutation } from "./_generated/server.js";
 import { v } from "convex/values";
+import { assert } from "convex-helpers";
 
 describe("workflow", () => {
   beforeEach(async () => {
@@ -709,6 +710,299 @@ describe("workflow", () => {
       expect(nested).toBeNull();
       expect(event).toBeNull();
     });
+  });
+
+  test("race by id transitions pre-created events to waiting then resolves", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.mutation(api.workflow.create, {
+      workflowName: "race-by-id",
+      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowArgs: {},
+      startAsync: true,
+    });
+
+    const idA = await t.mutation(api.event.create, {
+      name: "byIdA",
+      workflowId,
+    });
+    const idB = await t.mutation(api.event.create, {
+      name: "byIdB",
+      workflowId,
+    });
+
+    const entries = await t.mutation(api.journal.startSteps, {
+      workflowId,
+      generationNumber: 0,
+      steps: [
+        {
+          step: {
+            kind: "race" as const,
+            name: "race(byIdA, byIdB)",
+            inProgress: true,
+            argsSize: 0,
+            args: { events: [{ id: idA }, { id: idB }] },
+            startedAt: Date.now(),
+          },
+        },
+      ],
+    });
+    const raceStepId = entries[0]._id as Id<"steps">;
+
+    // Both pre-created events should now be "waiting" on the race step, and no
+    // duplicate events should have been created.
+    await t.run(async (ctx) => {
+      const all = await ctx.db
+        .query("events")
+        .withIndex("workflowId_state", (q) => q.eq("workflowId", workflowId))
+        .collect();
+      expect(all.length).toBe(2);
+      for (const event of all) {
+        expect(event.state.kind).toBe("waiting");
+        assert(event.state.kind === "waiting");
+        expect(event.state.stepId).toBe(raceStepId);
+      }
+      const step = await ctx.db.get(raceStepId);
+      assert(step && step.step.kind === "race");
+      expect(new Set(step.step.events?.map((e) => e.id))).toEqual(
+        new Set([idA, idB]),
+      );
+      expect(step.step.inProgress).toBe(true);
+    });
+
+    // Sending the first event by id wins the race; the loser is consumed.
+    await t.mutation(api.event.send, {
+      eventId: idA,
+      result: { kind: "success", returnValue: "winner" },
+    });
+
+    await t.run(async (ctx) => {
+      const step = await ctx.db.get(raceStepId);
+      assert(step && step.step.kind === "race");
+      expect(step.step.inProgress).toBe(false);
+      expect(step.step.raceWinnerEventId).toBe(idA);
+      expect(step.step.runResult).toEqual({
+        kind: "success",
+        returnValue: { eventName: "byIdA", eventId: idA, value: "winner" },
+      });
+      const eventA = await ctx.db.get(idA);
+      expect(eventA?.state.kind).toBe("consumed");
+      // The losing pre-created event is consumed (not deleted), so its id stays
+      // resolvable; it is keyed to the same race step as the winner.
+      const eventB = await ctx.db.get(idB);
+      expect(eventB?.state.kind).toBe("consumed");
+      assert(eventB?.state.kind === "consumed");
+      expect(eventB.state.stepId).toBe(raceStepId);
+    });
+  });
+
+  test("race synchronous completion consumes the winner and pre-created losers, leaves later-sent events alone", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.mutation(api.workflow.create, {
+      workflowName: "race-sync-cleanup",
+      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowArgs: {},
+      startAsync: true,
+    });
+
+    // A pre-created, never-sent event (id-based loser).
+    const idCreated = await t.mutation(api.event.create, {
+      name: "preCreated",
+      workflowId,
+    });
+    // Two events already "sent" before the race runs. The earliest-sent wins
+    // (default "fail" mode); the other was sent *after* the winner.
+    const winnerEventId = await t.mutation(api.event.send, {
+      workflowId,
+      name: "win",
+      result: { kind: "success", returnValue: "winner" },
+    });
+    const sentAfterWinnerId = await t.mutation(api.event.send, {
+      workflowId,
+      name: "loseSent",
+      result: { kind: "success", returnValue: "loser" },
+    });
+
+    const entries = await t.mutation(api.journal.startSteps, {
+      workflowId,
+      generationNumber: 0,
+      steps: [
+        {
+          step: {
+            kind: "race" as const,
+            name: "race(win, loseSent, preCreated)",
+            inProgress: true,
+            argsSize: 0,
+            args: {
+              events: [
+                { name: "win" },
+                { name: "loseSent" },
+                { id: idCreated },
+              ],
+            },
+            startedAt: Date.now(),
+          },
+        },
+      ],
+    });
+    const raceStepId = entries[0]._id as Id<"steps">;
+
+    await t.run(async (ctx) => {
+      const step = await ctx.db.get(raceStepId);
+      assert(step && step.step.kind === "race");
+      expect(step.step.inProgress).toBe(false);
+      expect(step.step.raceWinnerEventId).toBe(winnerEventId);
+      assert(step.step.runResult?.kind === "success");
+      expect(
+        (step.step.runResult.returnValue as { eventName: string }).eventName,
+      ).toBe("win");
+
+      // The winner and the never-sent pre-created event are consumed and keyed
+      // to the race step. The pre-created one is cleaned up because it was named
+      // explicitly by id; the winner because it won.
+      for (const id of [winnerEventId, idCreated]) {
+        const event = await ctx.db.get(id);
+        expect(event?.state.kind).toBe("consumed");
+        assert(event?.state.kind === "consumed");
+        expect(event.state.stepId).toBe(raceStepId);
+      }
+      // The event sent *after* the winner is left alone — it sits later on the
+      // timeline than the resolved race, exactly as if the race had been
+      // waiting and the event arrived a moment too late. It stays available for
+      // a later await/race.
+      const sentAfterWinner = await ctx.db.get(sentAfterWinnerId);
+      expect(sentAfterWinner?.state.kind).toBe("sent");
+    });
+  });
+
+  test("race discard consumes failures up to the winner, leaves events sent after it alone", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.mutation(api.workflow.create, {
+      workflowName: "race-discard-after-winner",
+      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowArgs: {},
+      startAsync: true,
+    });
+
+    // Sent in order: an error, then the winning success, then another success
+    // sent *after* the winner. Under "discard" the loop consumes the leading
+    // failure and stops at the first success; the event sent after it is later
+    // on the timeline and must be left untouched.
+    const erroredId = await t.mutation(api.event.send, {
+      workflowId,
+      name: "errored",
+      result: { kind: "failed", error: "boom" },
+    });
+    const winnerEventId = await t.mutation(api.event.send, {
+      workflowId,
+      name: "win",
+      result: { kind: "success", returnValue: "winner" },
+    });
+    const afterWinnerId = await t.mutation(api.event.send, {
+      workflowId,
+      name: "afterWinner",
+      result: { kind: "success", returnValue: "too late" },
+    });
+
+    const entries = await t.mutation(api.journal.startSteps, {
+      workflowId,
+      generationNumber: 0,
+      steps: [
+        {
+          step: {
+            kind: "race" as const,
+            name: "race(errored, win, afterWinner)",
+            inProgress: true,
+            argsSize: 0,
+            failure: "discard" as const,
+            args: {
+              events: [
+                { name: "errored" },
+                { name: "win" },
+                { name: "afterWinner" },
+              ],
+              failure: "discard",
+            },
+            startedAt: Date.now(),
+          },
+        },
+      ],
+    });
+    const raceStepId = entries[0]._id as Id<"steps">;
+
+    await t.run(async (ctx) => {
+      const step = await ctx.db.get(raceStepId);
+      assert(step && step.step.kind === "race");
+      expect(step.step.inProgress).toBe(false);
+      assert(step.step.runResult?.kind === "success");
+      expect(
+        (step.step.runResult.returnValue as { eventName: string }).eventName,
+      ).toBe("win");
+      expect(step.step.raceWinnerEventId).toBe(winnerEventId);
+
+      // The leading failure and the winner are consumed and keyed to the race
+      // step.
+      for (const id of [erroredId, winnerEventId]) {
+        const event = await ctx.db.get(id);
+        expect(event?.state.kind).toBe("consumed");
+        assert(event?.state.kind === "consumed");
+        expect(event.state.stepId).toBe(raceStepId);
+      }
+      // The success sent after the winner is left alone — it stays available
+      // for a later await/race rather than being swallowed by this race.
+      const afterWinner = await ctx.db.get(afterWinnerId);
+      expect(afterWinner?.state.kind).toBe("sent");
+    });
+  });
+
+  test("race by id throws when the event is already being awaited", async () => {
+    const t = initConvexTest();
+    const workflowId = await t.mutation(api.workflow.create, {
+      workflowName: "race-by-id-conflict",
+      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowArgs: {},
+      startAsync: true,
+    });
+    const eventId = await t.mutation(api.event.create, {
+      name: "awaited",
+      workflowId,
+    });
+
+    // Await the event first so it is in the "waiting" state.
+    await t.mutation(api.journal.startSteps, {
+      workflowId,
+      generationNumber: 0,
+      steps: [
+        {
+          step: {
+            kind: "event" as const,
+            name: "awaited",
+            inProgress: true,
+            argsSize: 0,
+            args: { eventId },
+            startedAt: Date.now(),
+          },
+        },
+      ],
+    });
+
+    await expect(
+      t.mutation(api.journal.startSteps, {
+        workflowId,
+        generationNumber: 0,
+        steps: [
+          {
+            step: {
+              kind: "race" as const,
+              name: "race(awaited, other)",
+              inProgress: true,
+              argsSize: 0,
+              args: { events: [{ id: eventId }, { name: "other" }] },
+              startedAt: Date.now(),
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow(/already waiting/);
   });
 });
 

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -38,6 +38,7 @@ import { api, internal } from "./_generated/api.js";
 import { formatErrorWithStack } from "../shared.js";
 import type { Doc, Id } from "./_generated/dataModel.js";
 import { paginator } from "convex-helpers/server/pagination";
+import { consumeRaceEvents } from "./race.js";
 
 const createArgs = v.object({
   workflowName: v.string(),
@@ -177,6 +178,16 @@ function publicStep(step: JournalEntry): WorkflowStep {
         ...commonFields,
         kind: "sleep",
         workId: step.step.workId!,
+      };
+    case "race":
+      return {
+        ...commonFields,
+        kind: "race" as const,
+        events: (step.step.events ?? []).map((e) => ({
+          id: e.id as unknown as EventId,
+          name: e.name,
+        })),
+        raceWinnerEventId: step.step.raceWinnerEventId as unknown as EventId,
       };
     default:
       throw new Error(`Unknown step kind: ${(step.step as any).kind}`);
@@ -406,17 +417,27 @@ export async function completeHandler(
       .collect();
     if (inProgress.length > 0) {
       const workpool = await getWorkpool(ctx, {});
-      for (const { step } of inProgress) {
-        if (!step.kind || step.kind === "function" || step.kind === "sleep") {
-          if (step.workId) {
-            await workpool.cancel(ctx, step.workId);
+      for (const entry of inProgress) {
+        if (
+          !entry.step.kind ||
+          entry.step.kind === "function" ||
+          entry.step.kind === "sleep"
+        ) {
+          if (entry.step.workId) {
+            await workpool.cancel(ctx, entry.step.workId);
           }
-        } else if (step.kind === "workflow") {
-          if (step.workflowId) {
+        } else if (entry.step.kind === "workflow") {
+          if (entry.step.workflowId) {
             await ctx.runMutation(api.workflow.cancel, {
-              workflowId: step.workflowId,
+              workflowId: entry.step.workflowId,
             });
           }
+        } else if (entry.step.kind === "race") {
+          await consumeRaceEvents(ctx, entry);
+          entry.step.runResult = { kind: "canceled" };
+          entry.step.inProgress = false;
+          entry.step.completedAt = Date.now();
+          await ctx.db.replace("steps", entry._id, entry);
         }
       }
     }
@@ -561,6 +582,21 @@ async function deleteSteps(ctx: MutationCtx, batch: Doc<"steps">[]) {
       await ctx.db.delete("steps", entry._id);
       if (entry.step.kind === "event" && entry.step.eventId) {
         await ctx.db.delete("events", entry.step.eventId);
+      } else if (entry.step.kind === "race") {
+        const raceEvents = await ctx.db
+          .query("events")
+          .withIndex("workflowId_state", (q) =>
+            q.eq("workflowId", entry.workflowId).eq("state.kind", "waiting"),
+          )
+          .filter((q) => q.eq(q.field("state.stepId"), entry._id))
+          .collect();
+        await Promise.all(
+          raceEvents.map((events) => ctx.db.delete("events", events._id)),
+        );
+        if (entry.step.timeout?.workId) {
+          const workpool = await getWorkpool(ctx, {});
+          await workpool.cancel(ctx, entry.step.timeout.workId);
+        }
       } else if (entry.step.kind === "workflow" && entry.step.workflowId) {
         nestedWorkflowIds.push(entry.step.workflowId);
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,11 @@ export type WorkflowStep = {
   | { kind: "workflow"; nestedWorkflowId: WorkflowId }
   | { kind: "event"; eventId: EventId }
   | { kind: "sleep"; workId: WorkId }
+  | {
+      kind: "race";
+      events: Array<{ id: EventId; name: string }>;
+      raceWinnerEventId?: EventId;
+    }
 );
 
 export const vWorkflowStep = v.object({
@@ -78,10 +83,13 @@ export const vWorkflowStep = v.object({
     v.literal("workflow"),
     v.literal("event"),
     v.literal("sleep"),
+    v.literal("race"),
   ),
   workId: v.optional(vWorkIdValidator),
   nestedWorkflowId: v.optional(vWorkflowId),
   eventId: v.optional(vEventId()),
+  events: v.optional(v.array(v.object({ id: vEventId(), name: v.string() }))),
+  raceWinnerEventId: v.optional(vEventId()),
 });
 // type assertion to keep us in check
 const _workflowStep: Infer<typeof vWorkflowStep> = {} as WorkflowStep;
@@ -127,6 +135,16 @@ export type OnCompleteArgs<Context = unknown> = {
    */
   result: RunResult;
 };
+
+export function vOnComplete<T extends Validator<Value, "required", string>>(
+  ctx: T,
+) {
+  return v.object({
+    workflowId: vWorkflowId,
+    context: ctx,
+    result: vResultValidator,
+  });
+}
 
 export function vPaginationResult<
   T extends Validator<Value, "required", string>,


### PR DESCRIPTION
<!-- Describe your PR here. -->

## Add `step.raceEvents` for waiting on multiple events

This PR introduces `step.raceEvents`, a new step type that lets a workflow wait
for **any one of multiple events** to fire. The first matching event resolves
the race and its name and value are returned as a typed discriminated union.

### What's included

- **`step.raceEvents(events, opts?)`** — new workflow step that blocks until one
  of the specified events is sent, or a timeout fires.
- **Three failure modes** — `"fail"` (default), `"retry"`, and `"discard"` to
  control how error events are handled.
- **Optional `timeout`** — schedules a timeout via the workpool that fails the
  race if no event arrives in time.
- **Typed return value** — uses the event validators to produce a discriminated
  union; narrowing on `result.name` gives you the correct `result.value` type.
- New internal `race` step kind in the schema, journal, and component layers.
- Cancellation and cleanup support for in-progress race steps.
- Example in `example/convex/raceEvents.ts`.
- Documentation in `README.md`.

### Design decisions

- **Event-based API, not arbitrary predicates.** For more nested or complicated
  use cases (e.g. combining events with sub-workflow results, complex state
  checks), users should bring their own separate workpool/workflow instances.
  Those scenarios typically need more control and observability over individual
  processes. An event-based race keeps the API simple and composable while
  delegating advanced orchestration to user code.

- **`timeout` is built-in despite the above.** Timeout is the exception because
  it is fundamental, common, and simple enough to implement at this level. More
  importantly, it provides runtime safety for the `"retry"` failure mode, which
  otherwise waits indefinitely unless it receives a success event. Without a
  built-in timeout, `"retry"` would be dangerous in practice.

- **Failure modes (`"fail"` / `"retry"` / `"discard"`).** These three modes
  cover the main use cases: accept the first event regardless, skip errors and
  wait for success, or skip errors and exhaust remaining events. The default
  (`"fail"`) matches the existing `awaitEvent` behavior where an error event
  throws in the handler.


# Missing
- [x] failure modes
- [x] documentation
- [x] examples
- [x] testing

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows can race multiple named events, with optional timeouts and configurable failure modes (fail, retry, discard).
  * Race steps return type-safe event results inferred from provided validators.
  * Added example workflows showing racing events, timeouts, and sending events to drive workflows.

* **Chores**
  * Public API updated to expose race result types and completion hooks for workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->