### PR TITLE
allow passing { unstableArgs } to step.run*

### DIFF
--- a/src/client/step.ts
+++ b/src/client/step.ts
@@ -47,6 +47,7 @@ export type StepRequest = {
       };
   retry: RetryBehavior | boolean | undefined;
   inline: boolean;
+  unstableArgs: boolean;
   schedulerOptions: SchedulerOptions;
 
   resolve: (result: RunResult) => void;
@@ -125,18 +126,23 @@ export class StepExecutor {
         `Assertion failed: not blocked but have in-progress journal entry`,
       );
     }
-    const stepJson = JSON.stringify(
-      convexToJson(pick(entry.step, ["name", "args", "kind"])),
+    const stepFields = pick(
+      entry.step,
+      message.unstableArgs ? ["name", "kind"] : ["name", "kind", "args"],
     );
-    const messageJson = JSON.stringify(
-      convexToJson({
-        name: message.name,
-        args: message.target.args as Value,
-        kind: message.target.kind,
-      }),
-    );
+    const messageFields = message.unstableArgs
+      ? { name: message.name, kind: message.target.kind }
+      : {
+          name: message.name,
+          kind: message.target.kind,
+          args: message.target.args as Value,
+        };
+    const stepJson = JSON.stringify(convexToJson(stepFields));
+    const messageJson = JSON.stringify(convexToJson(messageFields));
     if (stepJson !== messageJson) {
-      throw new Error(`Journal entry mismatch: ${stepJson} !== ${messageJson}`);
+      throw new Error(
+        `Journal entry mismatch:\n\n${stepJson}\n\n!==\n\n${messageJson}`,
+      );
     }
     if (entry.step.runResult === undefined) {
       throw new Error(

--- a/src/client/stepContext.test.ts
+++ b/src/client/stepContext.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, test } from "vitest";
 import { BaseChannel } from "async-channel";
 import type { RunResult } from "@convex-dev/workpool";
 import type { StepRequest } from "./step.js";
+import { StepExecutor } from "./step.js";
 import type { JournalEntry } from "../component/schema.js";
 import { createWorkflowCtx } from "./workflowContext.js";
 
@@ -342,5 +343,156 @@ describe("StepExecutor + WorkflowCtx integration", () => {
     ]);
 
     expect(result).toEqual([1, 2, 3]);
+  });
+});
+
+describe("unstableArgs", () => {
+  function makeMessage(opts: {
+    name: string;
+    kind: "function" | "workflow";
+    args: Record<string, unknown>;
+    unstableArgs: boolean;
+  }): StepRequest {
+    return {
+      name: opts.name,
+      target:
+        opts.kind === "function"
+          ? {
+              kind: "function",
+              functionType: "action",
+              function: fakeFuncRef(opts.name) as any,
+              args: opts.args,
+            }
+          : {
+              kind: "workflow",
+              function: fakeFuncRef(opts.name) as any,
+              args: opts.args,
+            },
+      retry: undefined,
+      inline: false,
+      unstableArgs: opts.unstableArgs,
+      schedulerOptions: {},
+      resolve: () => {},
+    };
+  }
+
+  function makeExecutor(entries: JournalEntry[]) {
+    return new StepExecutor(
+      "wf-test",
+      0,
+      {} as any,
+      {} as any,
+      entries,
+      new BaseChannel<StepRequest>(0),
+      Date.now(),
+      undefined,
+    );
+  }
+
+  const kinds = ["function", "workflow"] as const;
+
+  describe.each(kinds)("%s", (kind) => {
+    test("mismatched args fails without unstableArgs", () => {
+      const entry = journalEntry({
+        name: "step",
+        kind,
+        args: { x: 1 },
+      });
+      const executor = makeExecutor([entry]);
+      const message = makeMessage({
+        name: "step",
+        kind,
+        args: { x: 2 },
+        unstableArgs: false,
+      });
+      expect(() => executor.completeMessage(message, entry)).toThrow(
+        "Journal entry mismatch",
+      );
+    });
+
+    test("mismatched args succeeds with unstableArgs", () => {
+      const entry = journalEntry({
+        name: "step",
+        kind,
+        args: { x: 1 },
+      });
+      const executor = makeExecutor([entry]);
+      const message = makeMessage({
+        name: "step",
+        kind,
+        args: { x: 2 },
+        unstableArgs: true,
+      });
+      expect(() => executor.completeMessage(message, entry)).not.toThrow();
+    });
+
+    test("matching args succeeds with unstableArgs", () => {
+      const entry = journalEntry({
+        name: "step",
+        kind,
+        args: { x: 1 },
+      });
+      const executor = makeExecutor([entry]);
+      const message = makeMessage({
+        name: "step",
+        kind,
+        args: { x: 1 },
+        unstableArgs: true,
+      });
+      expect(() => executor.completeMessage(message, entry)).not.toThrow();
+    });
+  });
+
+  test("still validates name even with unstableArgs", () => {
+    const entry = journalEntry({ name: "original", args: { x: 1 } });
+    const executor = makeExecutor([entry]);
+    const message = makeMessage({
+      name: "different",
+      kind: "function",
+      args: { x: 2 },
+      unstableArgs: true,
+    });
+    expect(() => executor.completeMessage(message, entry)).toThrow(
+      "Journal entry mismatch",
+    );
+  });
+
+  test("unstableArgs passes through and defaults correctly", async () => {
+    const channel = new BaseChannel<StepRequest>(0);
+    const ctx = createWorkflowCtx("wf-test" as any, channel);
+
+    const calls: StepRequest[] = [];
+    const drain = async () => {
+      for (let i = 0; i < 8; i++) {
+        const msg = await channel.get();
+        calls.push(msg);
+        msg.resolve({ kind: "success", returnValue: null });
+      }
+    };
+
+    await Promise.all([
+      (async () => {
+        // With unstableArgs: true
+        await ctx.runQuery(fakeFuncRef("q") as any, {}, { unstableArgs: true });
+        await ctx.runMutation(fakeFuncRef("m") as any, {}, { unstableArgs: true });
+        await ctx.runAction(fakeFuncRef("a") as any, {}, { unstableArgs: true });
+        await ctx.runWorkflow(fakeFuncRef("w") as any, {}, { unstableArgs: true });
+        // Without unstableArgs (defaults to false)
+        await ctx.runQuery(fakeFuncRef("q2") as any, {});
+        await ctx.runMutation(fakeFuncRef("m2") as any, {});
+        await ctx.runAction(fakeFuncRef("a2") as any, {});
+        await ctx.runWorkflow(fakeFuncRef("w2") as any, {});
+      })(),
+      drain(),
+    ]);
+
+    expect(calls[0].unstableArgs).toBe(true);
+    expect(calls[1].unstableArgs).toBe(true);
+    expect(calls[2].unstableArgs).toBe(true);
+    expect(calls[3].unstableArgs).toBe(true);
+    expect(calls[4].unstableArgs).toBe(false);
+    expect(calls[5].unstableArgs).toBe(false);
+    expect(calls[6].unstableArgs).toBe(false);
+    expect(calls[7].unstableArgs).toBe(false);
   });
 });

--- a/src/client/workflowContext.ts
+++ b/src/client/workflowContext.ts
@@ -27,27 +27,7 @@ export type RunOptions = {
    * replay successfully despite argument changes.
    */
   unstableArgs?: boolean;
-} & (
-  | {
-      /**
-       * Run the query or mutation inline within the workflow's transaction,
-       * instead of dispatching it through the work pool.
-       *
-       * This avoids the round-trip overhead of scheduling through the work
-       * pool, but means the function shares the workflow's transaction —
-       * reads and writes are part of the same commit. Avoid using this for
-       * functions that read or write large amounts of data, since they will
-       * count toward the workflow transaction's limits.
-       *
-       * Only applies to queries and mutations. Actions always run via the
-       * work pool. Cannot be combined with `runAfter` or `runAt`.
-       */
-      inline?: boolean;
-      runAt?: never;
-      runAfter?: never;
-    }
-  | (SchedulerOptions & { inline?: never })
-);
+} & SchedulerOptions;
 
 export type WorkflowCtx = {
   /**
@@ -63,7 +43,7 @@ export type WorkflowCtx = {
    */
   runQuery<Query extends FunctionReference<"query", FunctionVisibility>>(
     query: Query,
-    ...args: OptionalRestArgs<RunOptions, Query>
+    ...args: OptionalRestArgs<RunOptions & { inline?: boolean }, Query>
   ): Promise<FunctionReturnType<Query>>;
 
   /**
@@ -77,7 +57,7 @@ export type WorkflowCtx = {
     Mutation extends FunctionReference<"mutation", FunctionVisibility>,
   >(
     mutation: Mutation,
-    ...args: OptionalRestArgs<RunOptions, Mutation>
+    ...args: OptionalRestArgs<RunOptions & { inline?: boolean }, Mutation>
   ): Promise<FunctionReturnType<Mutation>>;
 
   /**
@@ -217,7 +197,7 @@ async function runFunction<
   functionType: FunctionType,
   f: F,
   args: Record<string, unknown> | undefined,
-  opts?: RunOptions & RetryOption,
+  opts?: RunOptions & { inline?: boolean } & RetryOption,
 ): Promise<unknown> {
   const { name, retry, inline, unstableArgs, ...schedulerOptions } = opts ?? {};
   if (
@@ -225,6 +205,9 @@ async function runFunction<
     ("runAt" in schedulerOptions || "runAfter" in schedulerOptions)
   ) {
     throw new Error("Cannot combine `inline` with `runAt` or `runAfter`.");
+  }
+  if (inline && functionType === "action") {
+    throw new Error("Cannot run an action inline.");
   }
   return run(sender, {
     name: name ?? safeFunctionName(f),

--- a/src/client/workflowContext.ts
+++ b/src/client/workflowContext.ts
@@ -29,6 +29,16 @@ export type RunOptions = {
   unstableArgs?: boolean;
 } & SchedulerOptions;
 
+type InlineArgs =
+  | {
+      inline: true;
+      runAt?: never;
+      runAfter?: never;
+    }
+  | {
+      inline?: false;
+    };
+
 export type WorkflowCtx = {
   /**
    * The ID of the workflow currently running.
@@ -43,7 +53,7 @@ export type WorkflowCtx = {
    */
   runQuery<Query extends FunctionReference<"query", FunctionVisibility>>(
     query: Query,
-    ...args: OptionalRestArgs<RunOptions & { inline?: boolean }, Query>
+    ...args: OptionalRestArgs<RunOptions & InlineArgs, Query>
   ): Promise<FunctionReturnType<Query>>;
 
   /**
@@ -57,7 +67,7 @@ export type WorkflowCtx = {
     Mutation extends FunctionReference<"mutation", FunctionVisibility>,
   >(
     mutation: Mutation,
-    ...args: OptionalRestArgs<RunOptions & { inline?: boolean }, Mutation>
+    ...args: OptionalRestArgs<RunOptions & InlineArgs, Mutation>
   ): Promise<FunctionReturnType<Mutation>>;
 
   /**

--- a/src/client/workflowContext.ts
+++ b/src/client/workflowContext.ts
@@ -20,6 +20,13 @@ export type RunOptions = {
    * it will use the function handle directly.
    */
   name?: string;
+  /**
+   * If true, the journal will not validate that the arguments match on replay.
+   * This is useful when arguments are non-deterministic (e.g. derived from
+   * a stack trace caught in the workflow) and you want to allow the workflow to
+   * replay successfully despite argument changes.
+   */
+  unstableArgs?: boolean;
 } & (
   | {
       /**
@@ -154,7 +161,7 @@ export function createWorkflowCtx(
     },
 
     runWorkflow: async (workflow, args, opts?) => {
-      const { name, ...schedulerOptions } = opts ?? {};
+      const { name, unstableArgs, ...schedulerOptions } = opts ?? {};
       return run(sender, {
         name: name ?? safeFunctionName(workflow),
         target: {
@@ -164,6 +171,7 @@ export function createWorkflowCtx(
         },
         retry: undefined,
         inline: false,
+        unstableArgs: unstableArgs ?? false,
         schedulerOptions,
       });
     },
@@ -177,6 +185,7 @@ export function createWorkflowCtx(
         },
         retry: undefined,
         inline: false,
+        unstableArgs: false,
         schedulerOptions: { runAfter: duration },
       });
     },
@@ -190,6 +199,7 @@ export function createWorkflowCtx(
         },
         retry: undefined,
         inline: false,
+        unstableArgs: false,
         schedulerOptions: {},
       });
       if (event.validator) {
@@ -209,7 +219,7 @@ async function runFunction<
   args: Record<string, unknown> | undefined,
   opts?: RunOptions & RetryOption,
 ): Promise<unknown> {
-  const { name, retry, inline, ...schedulerOptions } = opts ?? {};
+  const { name, retry, inline, unstableArgs, ...schedulerOptions } = opts ?? {};
   if (
     inline &&
     ("runAt" in schedulerOptions || "runAfter" in schedulerOptions)
@@ -226,6 +236,7 @@ async function runFunction<
     },
     retry,
     inline: inline ?? false,
+    unstableArgs: unstableArgs ?? false,
     schedulerOptions,
   });
 }

--- a/src/client/workflowContext.ts
+++ b/src/client/workflowContext.ts
@@ -212,7 +212,8 @@ async function runFunction<
   const { name, retry, inline, unstableArgs, ...schedulerOptions } = opts ?? {};
   if (
     inline &&
-    ("runAt" in schedulerOptions || "runAfter" in schedulerOptions)
+    schedulerOptions &&
+    (schedulerOptions.runAt || schedulerOptions.runAfter)
   ) {
     throw new Error("Cannot combine `inline` with `runAt` or `runAfter`.");
   }


### PR DESCRIPTION
### TL;DR

Added `unstableArgs` option to workflow step execution that allows journal validation to skip argument comparison during replay.

### Why make this change?

This enables workflows to handle scenarios where step arguments are non-deterministic and may change between executions, such as when arguments are derived from stack traces or other runtime-dependent data. Without this option, such workflows would fail during replay due to argument mismatches in the journal validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->