### PR TITLE
fix: cast TestConvex generic in test helper to satisfy workpool.register

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -14,6 +14,13 @@ export function register<
   Schema extends SchemaDefinition<GenericSchema, boolean>,
 >(t: TestConvex<Schema>, name: string = "workflow") {
   t.registerComponent(name, schema, modules);
-  workpool.register(t, `${name}/workpool`);
+  // TestConvex<Schema> is invariant w.r.t. Schema, so a constrained generic
+  // parameter is not directly assignable to the concrete base type that
+  // workpool.register expects. The cast is safe: the value satisfies the
+  // interface at runtime.
+  workpool.register(
+    t as unknown as TestConvex<SchemaDefinition<GenericSchema, boolean>>,
+    `${name}/workpool`,
+  );
 }
 export default { register, schema, modules };


### PR DESCRIPTION
## Problem

Users who import `@convex-dev/workflow/test` and run `convex dev` (which invokes `tsc` on the convex directory) hit a **TS2345 type error** inside the package itself:

```
node_modules/@convex-dev/workflow/src/test.ts:17:21 - error TS2345:
Argument of type 'TestConvex<Schema>' is not assignable to parameter of type
'TestConvex<SchemaDefinition<GenericSchema, boolean>>'
```

## Root cause

TypeScript generics are **invariant** by default. Inside `register<Schema extends SchemaDefinition<...>>`, the local `t: TestConvex<Schema>` is a constrained generic — it is **not** assignable to `TestConvex<SchemaDefinition<GenericSchema, boolean>>` (the concrete base type) even though `Schema extends SchemaDefinition<GenericSchema, boolean>`. This is standard TypeScript variance behaviour.

`workpool.register` expects the concrete base type, so passing the constrained generic `t` directly fails the type check.

## Fix

Cast `t` to the concrete base type before passing it to `workpool.register`. The cast is safe at runtime — the object satisfies the interface regardless of which generic was inferred at the call site.

```ts
workpool.register(
  t as unknown as TestConvex<SchemaDefinition<GenericSchema, boolean>>,
  `${name}/workpool`,
);
```

## Reproduction

Use `@convex-dev/workflow@0.3.9` in a project that imports `workflowTest from "@convex-dev/workflow/test"` and run `tsc --noEmit -p convex/tsconfig.json`. The error appears on line 17 of `src/test.ts`.

## Related

Closes / related to #28 (convex-test compatibility).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal type handling for compatibility without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->