### PR TITLE
Add oversized values storage and retrieval

### DIFF
--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -303,6 +303,52 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         Name
       >;
     };
+    oversizedValues: {
+      list: FunctionReference<
+        "query",
+        "internal",
+        {
+          paginationOpts: {
+            cursor: string | null;
+            endCursor?: string | null;
+            id?: number;
+            maximumBytesRead?: number;
+            maximumRowsRead?: number;
+            numItems: number;
+          };
+        },
+        {
+          continueCursor: string;
+          isDone: boolean;
+          page: Array<{
+            _creationTime: number;
+            _id: string;
+            kind: "returnValue" | "args";
+            name: string;
+            stepId: string;
+            storageId: string;
+            workflowId: string;
+          }>;
+          pageStatus?: "SplitRecommended" | "SplitRequired" | null;
+          splitCursor?: string | null;
+        },
+        Name
+      >;
+      read: FunctionReference<
+        "action",
+        "internal",
+        { stepId: string },
+        any,
+        Name
+      >;
+      remove: FunctionReference<
+        "action",
+        "internal",
+        { stepId: string },
+        null,
+        Name
+      >;
+    };
     workflow: {
       cancel: FunctionReference<
         "mutation",

--- a/src/component/event.ts
+++ b/src/component/event.ts
@@ -41,7 +41,11 @@ export async function awaitEvent(
           stepId: entry._id,
         },
       });
-      entry.step.runResult = checkForOversizedResult(event.state.result);
+      entry.step.runResult = await checkForOversizedResult(
+        ctx,
+        event.state.result,
+        { stepId: entry._id },
+      );
       entry.step.inProgress = false;
       entry.step.completedAt = Date.now();
       break;
@@ -147,7 +151,11 @@ export const send = mutation({
         );
         assert(step.step.kind === "event", "Step is not an event");
         step.step.eventId = event._id;
-        step.step.runResult = checkForOversizedResult(args.result);
+        step.step.runResult = await checkForOversizedResult(
+          ctx,
+          args.result,
+          { stepId: step._id },
+        );
         step.step.inProgress = false;
         step.step.completedAt = Date.now();
         await ctx.db.replace("steps", step._id, step);

--- a/src/component/oversizedValues.ts
+++ b/src/component/oversizedValues.ts
@@ -1,5 +1,20 @@
-import { type Value, convexToJson, getConvexSize } from "convex/values";
+import { type Value, convexToJson, getConvexSize, jsonToConvex, v } from "convex/values";
+import { paginationOptsValidator, type PaginationResult } from "convex/server";
 import type { RunResult } from "@convex-dev/workpool";
+import { doc } from "convex-helpers/validators";
+import { paginator } from "convex-helpers/server/pagination";
+import {
+  action,
+  internalAction,
+  internalMutation,
+  internalQuery,
+  query,
+  type MutationCtx,
+} from "./_generated/server.js";
+import { internal } from "./_generated/api.js";
+import type { Doc, Id } from "./_generated/dataModel.js";
+import schema from "./schema.js";
+import { vPaginationResult } from "../types.js";
 
 export const MAX_RETURN_VALUE_SIZE = 800 << 10; // 800 KiB
 const PREVIEW_SIZE = 128 << 10; // 128 KB
@@ -17,12 +32,18 @@ export function checkReturnValueSize(
 ): string | null {
   const size = getConvexSize(returnValue);
   if (size > MAX_RETURN_VALUE_SIZE) {
-    return `Step return value too large (${size} bytes). Maximum is ${MAX_RETURN_VALUE_SIZE} bytes. Preview: ${truncatedPreview(returnValue)}`;
+    return `Step return value too large (${size} bytes). Maximum is ${MAX_RETURN_VALUE_SIZE} bytes. Retrieve it with ctx.runAction(components.workflow.oversizedValues.read, { stepId }). Preview: ${truncatedPreview(returnValue)}`;
   }
   return null;
 }
 
-export function checkForOversizedResult(result: RunResult): RunResult {
+export async function checkForOversizedResult(
+  ctx: MutationCtx,
+  result: RunResult,
+  opts: {
+    stepId: Id<"steps">;
+  },
+): Promise<RunResult> {
   if (result.kind !== "success") {
     return result;
   }
@@ -30,5 +51,137 @@ export function checkForOversizedResult(result: RunResult): RunResult {
   if (!sizeError) {
     return result;
   }
+  await ctx.scheduler.runAfter(0, internal.oversizedValues.store, {
+    kind: "returnValue" as const,
+    stepId: opts.stepId,
+    value: result.returnValue,
+  });
   return { kind: "failed", error: sizeError };
 }
+
+const vOversizedValueDoc = doc(schema, "oversizedValues");
+
+export const vKind = v.union(v.literal("returnValue"), v.literal("args"));
+
+export const store = internalAction({
+  args: {
+    kind: vKind,
+    stepId: v.id("steps"),
+    value: v.any(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const json = convexToJson(args.value as Value);
+    const blob = new Blob([JSON.stringify(json)]);
+    const storageId = await ctx.storage.store(blob);
+    await ctx.runMutation(internal.oversizedValues.save, {
+      kind: args.kind,
+      stepId: args.stepId,
+      storageId,
+    });
+    return null;
+  },
+});
+
+export const save = internalMutation({
+  args: {
+    kind: vKind,
+    stepId: v.id("steps"),
+    storageId: v.id("_storage"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const step = await ctx.db.get(args.stepId);
+    if (!step) {
+      throw new Error(`Step not found: ${args.stepId}`);
+    }
+    const workflow = await ctx.db.get(step.workflowId);
+    await ctx.db.insert("oversizedValues", {
+      workflowId: step.workflowId,
+      name: workflow?.name ?? "",
+      kind: args.kind,
+      stepId: args.stepId,
+      storageId: args.storageId,
+    });
+    return null;
+  },
+});
+
+export const get = internalQuery({
+  args: {
+    stepId: v.id("steps"),
+  },
+  returns: v.union(vOversizedValueDoc, v.null()),
+  handler: async (ctx, args): Promise<Doc<"oversizedValues"> | null> => {
+    return await ctx.db
+      .query("oversizedValues")
+      .withIndex("stepId", (q) => q.eq("stepId", args.stepId))
+      .first();
+  },
+});
+
+export const list = query({
+  args: {
+    paginationOpts: paginationOptsValidator,
+  },
+  returns: vPaginationResult(vOversizedValueDoc),
+  handler: async (ctx, args): Promise<PaginationResult<Doc<"oversizedValues">>> => {
+    return await paginator(ctx.db, schema)
+      .query("oversizedValues")
+      .paginate(args.paginationOpts);
+  },
+});
+
+export const read = action({
+  args: {
+    stepId: v.id("steps"),
+  },
+  returns: v.any(),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler: async (ctx, args): Promise<any> => {
+    const record = await ctx.runQuery(internal.oversizedValues.get, {
+      stepId: args.stepId,
+    });
+    if (!record) {
+      throw new Error(
+        `No oversized value found for step ${args.stepId}`,
+      );
+    }
+    const blob = await ctx.storage.get(record.storageId);
+    if (!blob) {
+      throw new Error(`Storage blob not found: ${record.storageId}`);
+    }
+    return jsonToConvex(JSON.parse(await blob.text()));
+  },
+});
+
+export const remove = action({
+  args: {
+    stepId: v.id("steps"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    await ctx.runMutation(internal.oversizedValues.deleteRecord, {
+      stepId: args.stepId,
+    });
+    return null;
+  },
+});
+
+export const deleteRecord = internalMutation({
+  args: {
+    stepId: v.id("steps"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const record = await ctx.db
+      .query("oversizedValues")
+      .withIndex("stepId", (q) => q.eq("stepId", args.stepId))
+      .first();
+    if (record) {
+      await ctx.storage.delete(record.storageId);
+      await ctx.db.delete(record._id);
+    }
+    return null;
+  },
+});

--- a/src/component/oversizedValues.ts
+++ b/src/component/oversizedValues.ts
@@ -91,11 +91,11 @@ export const save = internalMutation({
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
-    const step = await ctx.db.get(args.stepId);
+    const step = await ctx.db.get("steps", args.stepId);
     if (!step) {
       throw new Error(`Step not found: ${args.stepId}`);
     }
-    const workflow = await ctx.db.get(step.workflowId);
+    const workflow = await ctx.db.get("workflows", step.workflowId);
     await ctx.db.insert("oversizedValues", {
       workflowId: step.workflowId,
       name: workflow?.name ?? "",
@@ -180,7 +180,7 @@ export const deleteRecord = internalMutation({
       .first();
     if (record) {
       await ctx.storage.delete(record.storageId);
-      await ctx.db.delete(record._id);
+      await ctx.db.delete("oversizedValues", record._id);
     }
     return null;
   },

--- a/src/component/pool.ts
+++ b/src/component/pool.ts
@@ -148,7 +148,11 @@ async function onCompleteHandler(
   }
   journalEntry.step.inProgress = false;
   journalEntry.step.completedAt = Date.now();
-  const runResult = checkForOversizedResult(args.result);
+  const runResult = await checkForOversizedResult(
+    ctx,
+    args.result,
+    { stepId },
+  );
   journalEntry.step.runResult = runResult;
   await ctx.db.replace("steps", journalEntry._id, journalEntry);
   console.debug(`Completed execution of ${stepId}`, journalEntry);

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -122,6 +122,13 @@ export default defineSchema({
     "workflowId",
     "state.kind",
   ]),
+  oversizedValues: defineTable({
+    workflowId: v.id("workflows"),
+    name: v.string(),
+    kind: v.union(v.literal("returnValue"), v.literal("args")),
+    stepId: v.id("steps"),
+    storageId: v.id("_storage"),
+  }).index("stepId", ["stepId"]),
   onCompleteFailures: defineTable(
     v.union(
       v.object({

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -514,6 +514,14 @@ async function deleteSteps(ctx: MutationCtx, steps: Doc<"steps">[]) {
         force: true,
       });
     }
+    const oversized = await ctx.db
+      .query("oversizedValues")
+      .withIndex("stepId", (q) => q.eq("stepId", entry._id))
+      .first();
+    if (oversized) {
+      await ctx.storage.delete(oversized.storageId);
+      await ctx.db.delete(oversized._id);
+    }
   }
 }
 

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -520,7 +520,7 @@ async function deleteSteps(ctx: MutationCtx, steps: Doc<"steps">[]) {
       .first();
     if (oversized) {
       await ctx.storage.delete(oversized.storageId);
-      await ctx.db.delete(oversized._id);
+      await ctx.db.delete("oversizedValues", oversized._id);
     }
   }
 }


### PR DESCRIPTION
When a step result exceeds 1MB, store the full value in file storage
via an oversizedValues table so it can be retrieved later with
ctx.runAction(components.workflow.oversizedValues.read, { stepId }).

Adds list/read/remove public API, and cleans up stored values
when workflows are cleaned up.