### PR TITLE
export WorkflowArgs type

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -41,6 +41,7 @@ export {
   type WorkflowStep,
 } from "../types.js";
 export type { RunOptions, WorkflowCtx } from "./workflowContext.js";
+export type { WorkflowArgs } from "./workflowMutation.js";
 
 export type CallbackOptions = {
   /**


### PR DESCRIPTION
Without this re-export, downstream packages that emit declarations for values inferred from `workflow.define()` hit TS2742 ("the inferred type of X cannot be named without a reference to..."), because the inferred type names `WorkflowArgs<...>` via a non-portable internal module path. workos-authkit component is hitting this currently: https://github.com/get-convex/workos-authkit/actions/runs/25012829340/job/73252816400?pr=44#step:4:21

Convex js will also need an export of `ValidatorTypeToReturnType`, both are needed to fully restore the pre-0.3.10 emit behavior.


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
