### PR TITLE
delete workflow in batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Make `cleanup` resilient to workflows with many steps, events, and nested
+  workflows by yielding to a scheduled continuation before transaction limits
+  are hit (#255).
+
 ## 0.4.1
 
 - Support the alpha workpool

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "chokidar-cli": "3.0.0",
         "convex": "1.36.1",
         "convex-helpers": "0.1.114",
-        "convex-test": "0.0.50",
+        "convex-test": "0.0.52",
         "cpy-cli": "7.0.0",
         "eslint": "9.39.4",
         "eslint-plugin-react-hooks": "7.0.1",
@@ -2718,9 +2718,9 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.50.tgz",
-      "integrity": "sha512-rMNfrgcKJGToYDqNns2n1AO9KUP1NyC/AF9ldYEuWwTfRbgC9RQiHjlZsZQ/sOjLIVPUyKKIjoI/fNJUzy1urw==",
+      "version": "0.0.52",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.52.tgz",
+      "integrity": "sha512-C27plpAqg+5tT/whYaAoAAjSwl6bCNPZX/705nbijo1nu5L4Xnv1Ssd29KCvgM5liU5tvfo8Vz4o8Lu4wH+6fw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "chokidar-cli": "3.0.0",
     "convex": "1.36.1",
     "convex-helpers": "0.1.114",
-    "convex-test": "0.0.50",
+    "convex-test": "0.0.52",
     "cpy-cli": "7.0.0",
     "eslint": "9.39.4",
     "eslint-plugin-react-hooks": "7.0.1",

--- a/src/client/stepContext.test.ts
+++ b/src/client/stepContext.test.ts
@@ -5,16 +5,12 @@ import type { StepRequest } from "./step.js";
 import { StepExecutor } from "./step.js";
 import type { JournalEntry } from "../component/schema.js";
 import { createWorkflowCtx } from "./workflowContext.js";
+import type { WorkflowId } from "../types.js";
+import { anyApi, type FunctionReference } from "convex/server";
 
 // Fake function reference that satisfies the type constraints.
 function fakeFuncRef(name: string) {
-  return Object.assign(() => {}, {
-    _type: "function" as const,
-    _args: {} as Record<string, never>,
-    _returnType: undefined as unknown,
-    _visibility: "internal" as const,
-    [Symbol.for("functionName")]: name,
-  });
+  return anyApi[name].default as FunctionReference<any, "internal">;
 }
 
 // Build a completed journal entry for replay.
@@ -31,7 +27,7 @@ function journalEntry(
   const base = {
     _id: `step-${Math.random().toString(36).slice(2)}`,
     _creationTime: Date.now(),
-    workflowId: "wf-test" as any,
+    workflowId: "wf-test",
     stepNumber: overrides.stepNumber ?? 0,
   };
   const stepCommon = {
@@ -65,7 +61,7 @@ function journalEntry(
         ...stepCommon,
         args: overrides.args ?? { eventId: undefined },
       },
-    } as unknown as JournalEntry;
+    } as JournalEntry;
   }
   return {
     ...base,
@@ -74,7 +70,7 @@ function journalEntry(
       handle: "handle",
       ...stepCommon,
     },
-  } as unknown as JournalEntry;
+  } as JournalEntry;
 }
 
 // Simulate the StepExecutor replay loop: read messages from the channel and
@@ -98,7 +94,7 @@ async function replayFromJournal(
 describe("StepExecutor + WorkflowCtx integration", () => {
   it("resolves a successful step", async () => {
     const channel = new BaseChannel<StepRequest>(0);
-    const ctx = createWorkflowCtx("wf-1" as any, channel);
+    const ctx = createWorkflowCtx("wf-1" as WorkflowId, channel);
 
     const entry = journalEntry({
       name: "test",
@@ -106,7 +102,7 @@ describe("StepExecutor + WorkflowCtx integration", () => {
     });
 
     const [result] = await Promise.all([
-      ctx.runAction(fakeFuncRef("test") as any, {}),
+      ctx.runAction(fakeFuncRef("test"), {}),
       replayFromJournal(channel, [entry]),
     ]);
 
@@ -123,7 +119,7 @@ describe("StepExecutor + WorkflowCtx integration", () => {
     });
 
     const [error] = await Promise.all([
-      ctx.runAction(fakeFuncRef("test") as any, {}).catch((e: Error) => e),
+      ctx.runAction(fakeFuncRef("test"), {}).catch((e: Error) => e),
       replayFromJournal(channel, [entry]),
     ]);
 
@@ -141,7 +137,7 @@ describe("StepExecutor + WorkflowCtx integration", () => {
     });
 
     const [error] = await Promise.all([
-      ctx.runAction(fakeFuncRef("test") as any, {}).catch((e: Error) => e),
+      ctx.runAction(fakeFuncRef("test"), {}).catch((e: Error) => e),
       replayFromJournal(channel, [entry]),
     ]);
 
@@ -169,8 +165,8 @@ describe("StepExecutor + WorkflowCtx integration", () => {
     ];
 
     const handler = async () => {
-      const a = await ctx.runAction(fakeFuncRef("step1") as any, { x: 1 });
-      const b = await ctx.runAction(fakeFuncRef("step2") as any, { x: 2 });
+      const a = await ctx.runAction(fakeFuncRef("step1"), { x: 1 });
+      const b = await ctx.runAction(fakeFuncRef("step2"), { x: 2 });
       return [a, b];
     };
 
@@ -202,11 +198,11 @@ describe("StepExecutor + WorkflowCtx integration", () => {
     const handler = async () => {
       let caught: string | undefined;
       try {
-        await ctx.runAction(fakeFuncRef("failing") as any, {});
+        await ctx.runAction(fakeFuncRef("failing"), {});
       } catch (e) {
         caught = (e as Error).message;
       }
-      const result = await ctx.runAction(fakeFuncRef("recovery") as any, {});
+      const result = await ctx.runAction(fakeFuncRef("recovery"), {});
       return { caught, result };
     };
 
@@ -240,8 +236,8 @@ describe("StepExecutor + WorkflowCtx integration", () => {
 
     const handler = async () => {
       return Promise.all([
-        ctx.runAction(fakeFuncRef("a") as any, { v: "a" }),
-        ctx.runAction(fakeFuncRef("b") as any, { v: "b" }),
+        ctx.runAction(fakeFuncRef("a"), { v: "a" }),
+        ctx.runAction(fakeFuncRef("b"), { v: "b" }),
       ]);
     };
 
@@ -274,8 +270,8 @@ describe("StepExecutor + WorkflowCtx integration", () => {
 
     const handler = async () => {
       return Promise.all([
-        ctx.runAction(fakeFuncRef("ok") as any, { v: "ok" }),
-        ctx.runAction(fakeFuncRef("bad") as any, { v: "bad" }),
+        ctx.runAction(fakeFuncRef("ok"), { v: "ok" }),
+        ctx.runAction(fakeFuncRef("bad"), { v: "bad" }),
       ]);
     };
 
@@ -298,7 +294,7 @@ describe("StepExecutor + WorkflowCtx integration", () => {
     });
 
     const [error] = await Promise.all([
-      ctx.runAction(fakeFuncRef("test") as any, {}).catch((e: Error) => e),
+      ctx.runAction(fakeFuncRef("test"), {}).catch((e: Error) => e),
       replayFromJournal(channel, [entry]),
     ]);
 
@@ -321,7 +317,7 @@ describe("StepExecutor + WorkflowCtx integration", () => {
     });
 
     const [result] = await Promise.all([
-      ctx.runMutation(fakeFuncRef("mut") as any, {}),
+      ctx.runMutation(fakeFuncRef("mut"), {}),
       replayFromJournal(channel, [entry]),
     ]);
 
@@ -338,7 +334,7 @@ describe("StepExecutor + WorkflowCtx integration", () => {
     });
 
     const [result] = await Promise.all([
-      ctx.runQuery(fakeFuncRef("qry") as any, {}),
+      ctx.runQuery(fakeFuncRef("qry"), {}),
       replayFromJournal(channel, [entry]),
     ]);
 
@@ -360,12 +356,12 @@ describe("unstableArgs", () => {
           ? {
               kind: "function",
               functionType: "action",
-              function: fakeFuncRef(opts.name) as any,
+              function: fakeFuncRef(opts.name),
               args: opts.args,
             }
           : {
               kind: "workflow",
-              function: fakeFuncRef(opts.name) as any,
+              function: fakeFuncRef(opts.name),
               args: opts.args,
             },
       retry: undefined,
@@ -473,15 +469,15 @@ describe("unstableArgs", () => {
     await Promise.all([
       (async () => {
         // With unstableArgs: true
-        await ctx.runQuery(fakeFuncRef("q") as any, {}, { unstableArgs: true });
-        await ctx.runMutation(fakeFuncRef("m") as any, {}, { unstableArgs: true });
-        await ctx.runAction(fakeFuncRef("a") as any, {}, { unstableArgs: true });
-        await ctx.runWorkflow(fakeFuncRef("w") as any, {}, { unstableArgs: true });
+        await ctx.runQuery(fakeFuncRef("q"), {}, { unstableArgs: true });
+        await ctx.runMutation(fakeFuncRef("m"), {}, { unstableArgs: true });
+        await ctx.runAction(fakeFuncRef("a"), {}, { unstableArgs: true });
+        await ctx.runWorkflow(fakeFuncRef("w"), {}, { unstableArgs: true });
         // Without unstableArgs (defaults to false)
-        await ctx.runQuery(fakeFuncRef("q2") as any, {});
-        await ctx.runMutation(fakeFuncRef("m2") as any, {});
-        await ctx.runAction(fakeFuncRef("a2") as any, {});
-        await ctx.runWorkflow(fakeFuncRef("w2") as any, {});
+        await ctx.runQuery(fakeFuncRef("q2"), {});
+        await ctx.runMutation(fakeFuncRef("m2"), {});
+        await ctx.runAction(fakeFuncRef("a2"), {});
+        await ctx.runWorkflow(fakeFuncRef("w2"), {});
       })(),
       drain(),
     ]);

--- a/src/component/workflow.test.ts
+++ b/src/component/workflow.test.ts
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api.js";
 import { initConvexTest } from "./setup.test.js";
 import type { Id } from "./_generated/dataModel.js";
+import { internalMutation } from "./_generated/server.js";
+import { v } from "convex/values";
 
 describe("workflow", () => {
   beforeEach(async () => {
@@ -18,7 +20,7 @@ describe("workflow", () => {
     const t = initConvexTest();
     const id = await t.mutation(api.workflow.create, {
       workflowName: "test",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: { location: "San Francisco" },
       startAsync: true,
     });
@@ -33,7 +35,7 @@ describe("workflow", () => {
     const t = initConvexTest();
     const id = await t.mutation(api.workflow.create, {
       workflowName: "test",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: { location: "San Francisco" },
       startAsync: true,
     });
@@ -48,7 +50,7 @@ describe("workflow", () => {
     const t = initConvexTest();
     const id = await t.mutation(api.workflow.create, {
       workflowName: "test",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: { location: "San Francisco" },
       startAsync: true,
     });
@@ -76,7 +78,7 @@ describe("workflow", () => {
     const t = initConvexTest();
     const id = await t.mutation(api.workflow.create, {
       workflowName: "test",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: {},
       startAsync: true,
     });
@@ -89,7 +91,7 @@ describe("workflow", () => {
     const t = initConvexTest();
     const id = await t.mutation(api.workflow.create, {
       workflowName: "test",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: {},
       startAsync: true,
     });
@@ -102,7 +104,7 @@ describe("workflow", () => {
           step: {
             kind: "function" as const,
             functionType: "mutation" as const,
-            handle: "function://test",
+            handle: "function://;workflow.test:noop",
             name: `step${i}`,
             inProgress: false,
             argsSize: 0,
@@ -144,7 +146,7 @@ describe("workflow", () => {
     const t = initConvexTest();
     const id = await t.mutation(api.workflow.create, {
       workflowName: "test",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: {},
       startAsync: true,
     });
@@ -158,7 +160,7 @@ describe("workflow", () => {
           step: {
             kind: "function" as const,
             functionType: "action" as const,
-            handle: "function://test",
+            handle: "function://;workflow.test:noop",
             name: names[i],
             inProgress: false,
             argsSize: 0,
@@ -198,7 +200,7 @@ describe("workflow", () => {
     const t = initConvexTest();
     const id = await t.mutation(api.workflow.create, {
       workflowName: "test",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: {},
       startAsync: true,
     });
@@ -220,7 +222,7 @@ describe("workflow", () => {
     const t = initConvexTest();
     const id = await t.mutation(api.workflow.create, {
       workflowName: "test",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: {},
       startAsync: true,
     });
@@ -242,7 +244,7 @@ describe("workflow", () => {
     const t = initConvexTest();
     const id = await t.mutation(api.workflow.create, {
       workflowName: "test",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: {},
       startAsync: true,
     });
@@ -297,7 +299,7 @@ describe("workflow", () => {
     const t = initConvexTest();
     const id = await t.mutation(api.workflow.create, {
       workflowName: "test",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: { location: "San Francisco" },
       startAsync: true,
     });
@@ -320,7 +322,7 @@ describe("workflow", () => {
     // Create a workflow
     const workflowId = await t.mutation(api.workflow.create, {
       workflowName: "test-with-event",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: { location: "San Francisco" },
       startAsync: true,
     });
@@ -390,7 +392,7 @@ describe("workflow", () => {
     // Create a parent workflow
     const parentWorkflowId = await t.mutation(api.workflow.create, {
       workflowName: "parent-workflow",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: { location: "San Francisco" },
       startAsync: true,
     });
@@ -405,7 +407,7 @@ describe("workflow", () => {
           step: {
             kind: "workflow" as const,
             name: "nested-workflow-step",
-            handle: "function://internal.example.exampleWorkflow",
+            handle: "function://;workflow.test:noop",
             inProgress: true,
             argsSize: 0,
             args: { location: "New York" },
@@ -478,7 +480,7 @@ describe("workflow", () => {
     // Create a workflow
     const workflowId = await t.mutation(api.workflow.create, {
       workflowName: "test-workflow",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: { location: "San Francisco" },
       startAsync: true,
     });
@@ -492,7 +494,7 @@ describe("workflow", () => {
           step: {
             kind: "workflow" as const,
             name: "pending-nested-workflow",
-            handle: "function://internal.example.exampleWorkflow",
+            handle: "function://;workflow.test:noop",
             inProgress: true,
             argsSize: 0,
             args: { location: "Boston" },
@@ -522,7 +524,7 @@ describe("workflow", () => {
     // Create a workflow
     const workflowId = await t.mutation(api.workflow.create, {
       workflowName: "test-workflow",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: { location: "San Francisco" },
       startAsync: true,
     });
@@ -564,7 +566,7 @@ describe("workflow", () => {
 
     const workflowId = await t.mutation(api.workflow.create, {
       workflowName: "test-many-steps",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: {},
       startAsync: true,
     });
@@ -580,7 +582,7 @@ describe("workflow", () => {
           step: {
             kind: "function" as const,
             functionType: "mutation" as const,
-            handle: "function://test",
+            handle: "function://;workflow.test:noop",
             name: `step${i}`,
             inProgress: false,
             argsSize: 0,
@@ -618,7 +620,7 @@ describe("workflow", () => {
     // Create parent workflow
     const parentWorkflowId = await t.mutation(api.workflow.create, {
       workflowName: "parent-workflow",
-      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowHandle: "function://;workflow.test:noop",
       workflowArgs: { location: "San Francisco" },
       startAsync: true,
     });
@@ -649,7 +651,7 @@ describe("workflow", () => {
           step: {
             kind: "workflow" as const,
             name: "workflow-step",
-            handle: "function://internal.example.exampleWorkflow",
+            handle: "function://;workflow.test:noop",
             inProgress: true,
             argsSize: 0,
             args: { location: "New York" },
@@ -709,3 +711,5 @@ describe("workflow", () => {
     });
   });
 });
+
+export const noop = internalMutation({ args: v.any(), handler: () => {} });

--- a/src/component/workflow.test.ts
+++ b/src/component/workflow.test.ts
@@ -559,6 +559,59 @@ describe("workflow", () => {
     });
   });
 
+  test("cleanup deletes large numbers of steps via async iteration", async () => {
+    const t = initConvexTest();
+
+    const workflowId = await t.mutation(api.workflow.create, {
+      workflowName: "test-many-steps",
+      workflowHandle: "function://internal.example.exampleWorkflow",
+      workflowArgs: {},
+      startAsync: true,
+    });
+
+    // Insert many steps so the async iteration walks through them all and
+    // (in environments that enforce limits) any continuation kicks in.
+    const stepCount = 100;
+    await t.run(async (ctx) => {
+      for (let i = 0; i < stepCount; i++) {
+        await ctx.db.insert("steps", {
+          workflowId,
+          stepNumber: i,
+          step: {
+            kind: "function" as const,
+            functionType: "mutation" as const,
+            handle: "function://test",
+            name: `step${i}`,
+            inProgress: false,
+            argsSize: 0,
+            args: {},
+            runResult: { kind: "success", returnValue: null },
+            startedAt: Date.now(),
+            completedAt: Date.now(),
+          },
+        });
+      }
+    });
+
+    await t.mutation(api.workflow.cancel, { workflowId });
+
+    const cleaned = await t.mutation(api.workflow.cleanup, { workflowId });
+    expect(cleaned).toBe(true);
+
+    // Drain any continuations scheduled when budget was halfway consumed.
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await t.run(async (ctx) => {
+      const workflow = await ctx.db.get("workflows", workflowId);
+      expect(workflow).toBeNull();
+      const remaining = await ctx.db
+        .query("steps")
+        .withIndex("workflow", (q) => q.eq("workflowId", workflowId))
+        .collect();
+      expect(remaining).toHaveLength(0);
+    });
+  });
+
   test("cleanup with mixed event and workflow steps", async () => {
     const t = initConvexTest();
 

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -267,53 +267,46 @@ export async function restartHandler(
 
   // Delete steps from the specified point
   if (args.from !== undefined) {
-    let fromStepNumber: number;
-    let prefetched: Doc<"steps">[] | undefined;
     if (typeof args.from === "number") {
       if (args.from < 0) {
         throw new Error(`Step number cannot be negative: ${args.from}`);
       }
-      const firstMatching = await ctx.db
+      const stepsToDelete = await ctx.db
         .query("steps")
         .withIndex("workflow", (q) =>
           q
             .eq("workflowId", args.workflowId)
             .gte("stepNumber", args.from as number),
         )
-        .first();
-      if (!firstMatching) {
+        .collect();
+      if (stepsToDelete.length === 0) {
         console.warn(
           `Step number ${args.from} not found in workflow ${args.workflowId}`,
         );
       }
-      fromStepNumber = args.from;
+      await deleteSteps(ctx, stepsToDelete);
     } else {
-      // Walk backwards to find step by name, keeping the visited docs so
-      // deleteStepsFrom doesn't re-fetch them.
+      // Walk backwards to find step by name, collecting steps to delete
       const stepsDesc = ctx.db
         .query("steps")
         .withIndex("workflow", (q) => q.eq("workflowId", args.workflowId))
         .order("desc");
-      const visited: Doc<"steps">[] = [];
-      let found: number | null = null;
+      let found = false;
+      const toDelete: Doc<"steps">[] = [];
       for await (const step of stepsDesc) {
-        visited.push(step);
+        toDelete.push(step);
         if (step.step.name === args.from) {
-          found = step.stepNumber;
+          found = true;
           break;
         }
       }
-      if (found === null) {
+      if (!found) {
         throw new Error(
           `Step "${args.from}" not found in workflow ${args.workflowId}`,
         );
       }
-      fromStepNumber = found;
-      // Walk was descending; flip to ascending for deleteStepsFrom.
-      visited.reverse();
-      prefetched = visited;
+      await deleteSteps(ctx, toDelete);
     }
-    await deleteStepsFrom(ctx, args.workflowId, fromStepNumber, prefetched);
   }
 
   // Increment generation number and clear result
@@ -485,7 +478,7 @@ export const cleanup = mutation({
     }
     logger.debug(`Cleaning up workflow ${workflowId}`, workflow);
     await ctx.db.delete("workflows", workflowId);
-    await deleteStepsFrom(ctx, workflowId, 0);
+    await cleanupStepsFrom(ctx, workflowId, 0);
     return true;
   },
 });
@@ -497,12 +490,12 @@ export const cleanupContinue = internalMutation({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    await deleteStepsFrom(ctx, args.workflowId, args.fromStepNumber);
+    await cleanupStepsFrom(ctx, args.workflowId, args.fromStepNumber);
     return null;
   },
 });
 
-const DELETE_STEPS_BATCH_SIZE = 256;
+const CLEANUP_BATCH_SIZE = 256;
 
 async function transactionBudgetMostlyConsumed(
   ctx: MutationCtx,
@@ -535,32 +528,22 @@ async function updateMaxParallelism(
   }
 }
 
-async function deleteStepsFrom(
+async function cleanupStepsFrom(
   ctx: MutationCtx,
   workflowId: Id<"workflows">,
   fromStepNumber: number,
-  prefetched?: Doc<"steps">[],
 ) {
-  // `prefetched` must be in ascending stepNumber order so each batch's last
-  // entry is the highest stepNumber processed.
-  let remaining = prefetched ?? [];
   while (true) {
-    let batch: Doc<"steps">[];
-    if (remaining.length > 0) {
-      batch = remaining.slice(0, DELETE_STEPS_BATCH_SIZE);
-      remaining = remaining.slice(DELETE_STEPS_BATCH_SIZE);
-    } else {
-      batch = await ctx.db
-        .query("steps")
-        .withIndex("workflow", (q) =>
-          q.eq("workflowId", workflowId).gte("stepNumber", fromStepNumber),
-        )
-        .take(DELETE_STEPS_BATCH_SIZE);
-      if (batch.length === 0) return;
-    }
-    await deleteStepBatch(ctx, batch);
+    const batch = await ctx.db
+      .query("steps")
+      .withIndex("workflow", (q) =>
+        q.eq("workflowId", workflowId).gte("stepNumber", fromStepNumber),
+      )
+      .take(CLEANUP_BATCH_SIZE);
+    if (batch.length === 0) return;
+    await deleteSteps(ctx, batch);
     fromStepNumber = batch[batch.length - 1].stepNumber + 1;
-    if (batch.length < DELETE_STEPS_BATCH_SIZE) return;
+    if (batch.length < CLEANUP_BATCH_SIZE) return;
     if (await transactionBudgetMostlyConsumed(ctx)) {
       await ctx.scheduler.runAfter(0, internal.workflow.cleanupContinue, {
         workflowId,
@@ -571,16 +554,18 @@ async function deleteStepsFrom(
   }
 }
 
-async function deleteStepBatch(ctx: MutationCtx, batch: Doc<"steps">[]) {
+async function deleteSteps(ctx: MutationCtx, batch: Doc<"steps">[]) {
   const nestedWorkflowIds: Id<"workflows">[] = [];
-  for (const entry of batch) {
-    await ctx.db.delete("steps", entry._id);
-    if (entry.step.kind === "event" && entry.step.eventId) {
-      await ctx.db.delete("events", entry.step.eventId);
-    } else if (entry.step.kind === "workflow" && entry.step.workflowId) {
-      nestedWorkflowIds.push(entry.step.workflowId);
-    }
-  }
+  await Promise.all(
+    batch.map(async (entry) => {
+      await ctx.db.delete("steps", entry._id);
+      if (entry.step.kind === "event" && entry.step.eventId) {
+        await ctx.db.delete("events", entry.step.eventId);
+      } else if (entry.step.kind === "workflow" && entry.step.workflowId) {
+        nestedWorkflowIds.push(entry.step.workflowId);
+      }
+    }),
+  );
   if (nestedWorkflowIds.length > 0) {
     const workpool = await getWorkpool(ctx, {});
     await workpool.enqueueMutationBatch(

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -7,6 +7,7 @@ import {
 } from "convex/server";
 import { type Infer, v } from "convex/values";
 import {
+  internalMutation,
   internalQuery,
   mutation,
   type MutationCtx,
@@ -477,14 +478,82 @@ export const cleanup = mutation({
     }
     logger.debug(`Cleaning up workflow ${workflowId}`, workflow);
     await ctx.db.delete("workflows", workflowId);
-    const journalEntries = await ctx.db
-      .query("steps")
-      .withIndex("workflow", (q) => q.eq("workflowId", workflowId))
-      .collect();
-    await deleteSteps(ctx, journalEntries);
+    await cleanupStepsFrom(ctx, workflowId, 0);
     return true;
   },
 });
+
+export const cleanupContinue = internalMutation({
+  args: {
+    workflowId: v.id("workflows"),
+    fromStepNumber: v.number(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await cleanupStepsFrom(ctx, args.workflowId, args.fromStepNumber);
+    return null;
+  },
+});
+
+async function cleanupStepsFrom(
+  ctx: MutationCtx,
+  workflowId: Id<"workflows">,
+  fromStepNumber: number,
+) {
+  const nestedWorkflowIds: Id<"workflows">[] = [];
+  const steps = ctx.db
+    .query("steps")
+    .withIndex("workflow", (q) =>
+      q.eq("workflowId", workflowId).gte("stepNumber", fromStepNumber),
+    );
+  for await (const entry of steps) {
+    await ctx.db.delete("steps", entry._id);
+    if (entry.step.kind === "event" && entry.step.eventId) {
+      await ctx.db.delete("events", entry.step.eventId);
+    } else if (entry.step.kind === "workflow" && entry.step.workflowId) {
+      nestedWorkflowIds.push(entry.step.workflowId);
+    }
+    if (await transactionBudgetMostlyConsumed(ctx)) {
+      await ctx.scheduler.runAfter(0, internal.workflow.cleanupContinue, {
+        workflowId,
+        fromStepNumber: entry.stepNumber + 1,
+      });
+      break;
+    }
+  }
+  await flushNestedCleanup(ctx, nestedWorkflowIds);
+}
+
+async function flushNestedCleanup(
+  ctx: MutationCtx,
+  nestedWorkflowIds: Id<"workflows">[],
+) {
+  if (nestedWorkflowIds.length === 0) return;
+  // Fetch workpool / config once and enqueue in a single batch so we don't
+  // pay the per-step cost (config .first(), workpool enqueue subqueries) for
+  // every nested workflow.
+  const workpool = await getWorkpool(ctx, {});
+  await workpool.enqueueMutationBatch(
+    ctx,
+    api.workflow.cleanup,
+    nestedWorkflowIds.map((workflowId) => ({ workflowId, force: true })),
+  );
+}
+
+async function transactionBudgetMostlyConsumed(
+  ctx: MutationCtx,
+): Promise<boolean> {
+  const m = await ctx.meta.getTransactionMetrics();
+  return (
+    m.bytesRead.used > m.bytesRead.remaining ||
+    m.bytesWritten.used > m.bytesWritten.remaining ||
+    m.databaseQueries.used > m.databaseQueries.remaining ||
+    m.documentsRead.used > m.documentsRead.remaining ||
+    m.documentsWritten.used > m.documentsWritten.remaining ||
+    m.functionsScheduled.used > m.functionsScheduled.remaining ||
+    m.scheduledFunctionArgsBytes.used > m.scheduledFunctionArgsBytes.remaining
+  );
+}
 
 async function updateMaxParallelism(
   ctx: MutationCtx,
@@ -503,18 +572,16 @@ async function updateMaxParallelism(
 }
 
 async function deleteSteps(ctx: MutationCtx, steps: Doc<"steps">[]) {
+  const nestedWorkflowIds: Id<"workflows">[] = [];
   for (const entry of steps) {
     await ctx.db.delete("steps", entry._id);
     if (entry.step.kind === "event" && entry.step.eventId) {
       await ctx.db.delete("events", entry.step.eventId);
     } else if (entry.step.kind === "workflow" && entry.step.workflowId) {
-      const workpool = await getWorkpool(ctx, {});
-      await workpool.enqueueMutation(ctx, api.workflow.cleanup, {
-        workflowId: entry.step.workflowId,
-        force: true,
-      });
+      nestedWorkflowIds.push(entry.step.workflowId);
     }
   }
+  await flushNestedCleanup(ctx, nestedWorkflowIds);
 }
 
 export const sleep = internalQuery({

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -495,49 +495,31 @@ export const cleanupContinue = internalMutation({
   },
 });
 
+const CLEANUP_BATCH_SIZE = 256;
+
 async function cleanupStepsFrom(
   ctx: MutationCtx,
   workflowId: Id<"workflows">,
   fromStepNumber: number,
 ) {
-  const nestedWorkflowIds: Id<"workflows">[] = [];
-  const steps = ctx.db
-    .query("steps")
-    .withIndex("workflow", (q) =>
-      q.eq("workflowId", workflowId).gte("stepNumber", fromStepNumber),
-    );
-  for await (const entry of steps) {
-    await ctx.db.delete("steps", entry._id);
-    if (entry.step.kind === "event" && entry.step.eventId) {
-      await ctx.db.delete("events", entry.step.eventId);
-    } else if (entry.step.kind === "workflow" && entry.step.workflowId) {
-      nestedWorkflowIds.push(entry.step.workflowId);
-    }
+  while (true) {
+    const batch = await ctx.db
+      .query("steps")
+      .withIndex("workflow", (q) =>
+        q.eq("workflowId", workflowId).gte("stepNumber", fromStepNumber),
+      )
+      .take(CLEANUP_BATCH_SIZE);
+    if (batch.length === 0) return;
+    await deleteSteps(ctx, batch);
+    if (batch.length < CLEANUP_BATCH_SIZE) return;
     if (await transactionBudgetMostlyConsumed(ctx)) {
       await ctx.scheduler.runAfter(0, internal.workflow.cleanupContinue, {
         workflowId,
-        fromStepNumber: entry.stepNumber + 1,
+        fromStepNumber: batch[batch.length - 1].stepNumber + 1,
       });
-      break;
+      return;
     }
   }
-  await flushNestedCleanup(ctx, nestedWorkflowIds);
-}
-
-async function flushNestedCleanup(
-  ctx: MutationCtx,
-  nestedWorkflowIds: Id<"workflows">[],
-) {
-  if (nestedWorkflowIds.length === 0) return;
-  // Fetch workpool / config once and enqueue in a single batch so we don't
-  // pay the per-step cost (config .first(), workpool enqueue subqueries) for
-  // every nested workflow.
-  const workpool = await getWorkpool(ctx, {});
-  await workpool.enqueueMutationBatch(
-    ctx,
-    api.workflow.cleanup,
-    nestedWorkflowIds.map((workflowId) => ({ workflowId, force: true })),
-  );
 }
 
 async function transactionBudgetMostlyConsumed(
@@ -581,7 +563,13 @@ async function deleteSteps(ctx: MutationCtx, steps: Doc<"steps">[]) {
       nestedWorkflowIds.push(entry.step.workflowId);
     }
   }
-  await flushNestedCleanup(ctx, nestedWorkflowIds);
+  // Fetch workpool / config once and enqueue in a single batch
+  const workpool = await getWorkpool(ctx, {});
+  await workpool.enqueueMutationBatch(
+    ctx,
+    api.workflow.cleanup,
+    nestedWorkflowIds.map((workflowId) => ({ workflowId, force: true })),
+  );
 }
 
 export const sleep = internalQuery({

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -309,6 +309,8 @@ export async function restartHandler(
         );
       }
       fromStepNumber = found;
+      // Walk was descending; flip to ascending for deleteStepsFrom.
+      visited.reverse();
       prefetched = visited;
     }
     await deleteStepsFrom(ctx, args.workflowId, fromStepNumber, prefetched);
@@ -539,33 +541,30 @@ async function deleteStepsFrom(
   fromStepNumber: number,
   prefetched?: Doc<"steps">[],
 ) {
-  if (prefetched && prefetched.length > 0) {
-    for (let i = 0; i < prefetched.length; i += DELETE_STEPS_BATCH_SIZE) {
-      const batch = prefetched.slice(i, i + DELETE_STEPS_BATCH_SIZE);
-      await deleteStepBatch(ctx, batch);
-      if (await transactionBudgetMostlyConsumed(ctx)) {
-        await ctx.scheduler.runAfter(0, internal.workflow.cleanupContinue, {
-          workflowId,
-          fromStepNumber,
-        });
-        return;
-      }
-    }
-  }
+  // `prefetched` must be in ascending stepNumber order so each batch's last
+  // entry is the highest stepNumber processed.
+  let remaining = prefetched ?? [];
   while (true) {
-    const batch = await ctx.db
-      .query("steps")
-      .withIndex("workflow", (q) =>
-        q.eq("workflowId", workflowId).gte("stepNumber", fromStepNumber),
-      )
-      .take(DELETE_STEPS_BATCH_SIZE);
-    if (batch.length === 0) return;
+    let batch: Doc<"steps">[];
+    if (remaining.length > 0) {
+      batch = remaining.slice(0, DELETE_STEPS_BATCH_SIZE);
+      remaining = remaining.slice(DELETE_STEPS_BATCH_SIZE);
+    } else {
+      batch = await ctx.db
+        .query("steps")
+        .withIndex("workflow", (q) =>
+          q.eq("workflowId", workflowId).gte("stepNumber", fromStepNumber),
+        )
+        .take(DELETE_STEPS_BATCH_SIZE);
+      if (batch.length === 0) return;
+    }
     await deleteStepBatch(ctx, batch);
+    fromStepNumber = batch[batch.length - 1].stepNumber + 1;
     if (batch.length < DELETE_STEPS_BATCH_SIZE) return;
     if (await transactionBudgetMostlyConsumed(ctx)) {
       await ctx.scheduler.runAfter(0, internal.workflow.cleanupContinue, {
         workflowId,
-        fromStepNumber: batch[batch.length - 1].stepNumber + 1,
+        fromStepNumber,
       });
       return;
     }

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -267,46 +267,51 @@ export async function restartHandler(
 
   // Delete steps from the specified point
   if (args.from !== undefined) {
+    let fromStepNumber: number;
+    let prefetched: Doc<"steps">[] | undefined;
     if (typeof args.from === "number") {
       if (args.from < 0) {
         throw new Error(`Step number cannot be negative: ${args.from}`);
       }
-      const stepsToDelete = await ctx.db
+      const firstMatching = await ctx.db
         .query("steps")
         .withIndex("workflow", (q) =>
           q
             .eq("workflowId", args.workflowId)
             .gte("stepNumber", args.from as number),
         )
-        .collect();
-      if (stepsToDelete.length === 0) {
+        .first();
+      if (!firstMatching) {
         console.warn(
           `Step number ${args.from} not found in workflow ${args.workflowId}`,
         );
       }
-      await deleteSteps(ctx, stepsToDelete);
+      fromStepNumber = args.from;
     } else {
-      // Walk backwards to find step by name, collecting steps to delete
+      // Walk backwards to find step by name, keeping the visited docs so
+      // deleteStepsFrom doesn't re-fetch them.
       const stepsDesc = ctx.db
         .query("steps")
         .withIndex("workflow", (q) => q.eq("workflowId", args.workflowId))
         .order("desc");
-      let found = false;
-      const toDelete: Doc<"steps">[] = [];
+      const visited: Doc<"steps">[] = [];
+      let found: number | null = null;
       for await (const step of stepsDesc) {
-        toDelete.push(step);
+        visited.push(step);
         if (step.step.name === args.from) {
-          found = true;
+          found = step.stepNumber;
           break;
         }
       }
-      if (!found) {
+      if (found === null) {
         throw new Error(
           `Step "${args.from}" not found in workflow ${args.workflowId}`,
         );
       }
-      await deleteSteps(ctx, toDelete);
+      fromStepNumber = found;
+      prefetched = visited;
     }
+    await deleteStepsFrom(ctx, args.workflowId, fromStepNumber, prefetched);
   }
 
   // Increment generation number and clear result
@@ -478,7 +483,7 @@ export const cleanup = mutation({
     }
     logger.debug(`Cleaning up workflow ${workflowId}`, workflow);
     await ctx.db.delete("workflows", workflowId);
-    await cleanupStepsFrom(ctx, workflowId, 0);
+    await deleteStepsFrom(ctx, workflowId, 0);
     return true;
   },
 });
@@ -490,37 +495,12 @@ export const cleanupContinue = internalMutation({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    await cleanupStepsFrom(ctx, args.workflowId, args.fromStepNumber);
+    await deleteStepsFrom(ctx, args.workflowId, args.fromStepNumber);
     return null;
   },
 });
 
-const CLEANUP_BATCH_SIZE = 256;
-
-async function cleanupStepsFrom(
-  ctx: MutationCtx,
-  workflowId: Id<"workflows">,
-  fromStepNumber: number,
-) {
-  while (true) {
-    const batch = await ctx.db
-      .query("steps")
-      .withIndex("workflow", (q) =>
-        q.eq("workflowId", workflowId).gte("stepNumber", fromStepNumber),
-      )
-      .take(CLEANUP_BATCH_SIZE);
-    if (batch.length === 0) return;
-    await deleteSteps(ctx, batch);
-    if (batch.length < CLEANUP_BATCH_SIZE) return;
-    if (await transactionBudgetMostlyConsumed(ctx)) {
-      await ctx.scheduler.runAfter(0, internal.workflow.cleanupContinue, {
-        workflowId,
-        fromStepNumber: batch[batch.length - 1].stepNumber + 1,
-      });
-      return;
-    }
-  }
-}
+const DELETE_STEPS_BATCH_SIZE = 256;
 
 async function transactionBudgetMostlyConsumed(
   ctx: MutationCtx,
@@ -553,9 +533,48 @@ async function updateMaxParallelism(
   }
 }
 
-async function deleteSteps(ctx: MutationCtx, steps: Doc<"steps">[]) {
+async function deleteStepsFrom(
+  ctx: MutationCtx,
+  workflowId: Id<"workflows">,
+  fromStepNumber: number,
+  prefetched?: Doc<"steps">[],
+) {
+  if (prefetched && prefetched.length > 0) {
+    for (let i = 0; i < prefetched.length; i += DELETE_STEPS_BATCH_SIZE) {
+      const batch = prefetched.slice(i, i + DELETE_STEPS_BATCH_SIZE);
+      await deleteStepBatch(ctx, batch);
+      if (await transactionBudgetMostlyConsumed(ctx)) {
+        await ctx.scheduler.runAfter(0, internal.workflow.cleanupContinue, {
+          workflowId,
+          fromStepNumber,
+        });
+        return;
+      }
+    }
+  }
+  while (true) {
+    const batch = await ctx.db
+      .query("steps")
+      .withIndex("workflow", (q) =>
+        q.eq("workflowId", workflowId).gte("stepNumber", fromStepNumber),
+      )
+      .take(DELETE_STEPS_BATCH_SIZE);
+    if (batch.length === 0) return;
+    await deleteStepBatch(ctx, batch);
+    if (batch.length < DELETE_STEPS_BATCH_SIZE) return;
+    if (await transactionBudgetMostlyConsumed(ctx)) {
+      await ctx.scheduler.runAfter(0, internal.workflow.cleanupContinue, {
+        workflowId,
+        fromStepNumber: batch[batch.length - 1].stepNumber + 1,
+      });
+      return;
+    }
+  }
+}
+
+async function deleteStepBatch(ctx: MutationCtx, batch: Doc<"steps">[]) {
   const nestedWorkflowIds: Id<"workflows">[] = [];
-  for (const entry of steps) {
+  for (const entry of batch) {
     await ctx.db.delete("steps", entry._id);
     if (entry.step.kind === "event" && entry.step.eventId) {
       await ctx.db.delete("events", entry.step.eventId);
@@ -563,13 +582,14 @@ async function deleteSteps(ctx: MutationCtx, steps: Doc<"steps">[]) {
       nestedWorkflowIds.push(entry.step.workflowId);
     }
   }
-  // Fetch workpool / config once and enqueue in a single batch
-  const workpool = await getWorkpool(ctx, {});
-  await workpool.enqueueMutationBatch(
-    ctx,
-    api.workflow.cleanup,
-    nestedWorkflowIds.map((workflowId) => ({ workflowId, force: true })),
-  );
+  if (nestedWorkflowIds.length > 0) {
+    const workpool = await getWorkpool(ctx, {});
+    await workpool.enqueueMutationBatch(
+      ctx,
+      api.workflow.cleanup,
+      nestedWorkflowIds.map((id) => ({ workflowId: id, force: true })),
+    );
+  }
 }
 
 export const sleep = internalQuery({


### PR DESCRIPTION
## Make `cleanup` resilient to transaction limits

Fixes #255

Workflow cleanup now deletes steps in batches rather than collecting all steps at once. After each batch, the transaction budget is checked, and if it is mostly consumed, a scheduled continuation (`cleanupContinue`) is enqueued to pick up where deletion left off.

### Share `deleteStepsFrom`

`restartHandler` and `cleanup` now both route through a single `deleteStepsFrom` helper, replacing the old `deleteSteps` function that operated on a pre-fetched slice.

### All step deletion is batched

`deleteStepBatch` accumulates nested workflow IDs encountered during a batch and enqueues their cleanup in a single `enqueueMutationBatch` call rather than one `enqueueMutation` per step.