### PR TITLE
reduce preview size when object too large

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "chokidar-cli": "3.0.0",
         "convex": "1.36.1",
         "convex-helpers": "0.1.114",
-        "convex-test": "0.0.50",
+        "convex-test": "0.0.52",
         "cpy-cli": "7.0.0",
         "eslint": "9.39.4",
         "eslint-plugin-react-hooks": "7.0.1",
@@ -2718,9 +2718,9 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.50.tgz",
-      "integrity": "sha512-rMNfrgcKJGToYDqNns2n1AO9KUP1NyC/AF9ldYEuWwTfRbgC9RQiHjlZsZQ/sOjLIVPUyKKIjoI/fNJUzy1urw==",
+      "version": "0.0.52",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.52.tgz",
+      "integrity": "sha512-C27plpAqg+5tT/whYaAoAAjSwl6bCNPZX/705nbijo1nu5L4Xnv1Ssd29KCvgM5liU5tvfo8Vz4o8Lu4wH+6fw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "chokidar-cli": "3.0.0",
     "convex": "1.36.1",
     "convex-helpers": "0.1.114",
-    "convex-test": "0.0.50",
+    "convex-test": "0.0.52",
     "cpy-cli": "7.0.0",
     "eslint": "9.39.4",
     "eslint-plugin-react-hooks": "7.0.1",

--- a/src/component/oversizedValues.ts
+++ b/src/component/oversizedValues.ts
@@ -1,8 +1,8 @@
 import { type Value, convexToJson, getConvexSize } from "convex/values";
 import type { RunResult } from "@convex-dev/workpool";
 
-export const MAX_RETURN_VALUE_SIZE = 800 << 10; // 800 KiB
-const PREVIEW_SIZE = 128 << 10; // 128 KB
+export const MAX_RETURN_VALUE_SIZE = 800 << 10;
+const PREVIEW_SIZE = 8 << 10;
 
 function truncatedPreview(returnValue: unknown): string {
   const json = JSON.stringify(convexToJson(returnValue as Value));


### PR DESCRIPTION
256Kb * 2 is too much to put into logs / errors. reduce to 8k for now