### PR TITLE
allow targeted default settings for step WorkflowCtx

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,9 +476,9 @@ export const scrapeAll = workflow.define({
   handler: async (step, { urls }) => {
     // Workpool embeds its config in its enqueue arguments, so changing e.g.
     // maxParallelism would otherwise fail replays of in-flight workflows.
-    const lenient = step.withOptions({ unstableArgs: true });
+    const lenientStep = step.withOptions({ unstableArgs: true });
     for (const url of urls) {
-      await pool.enqueueAction(lenient, internal.scrape.page, { url });
+      await pool.enqueueAction(lenientStep, internal.scrape.page, { url });
     }
   },
 });

--- a/README.md
+++ b/README.md
@@ -447,6 +447,47 @@ If a step reads or writes a large amount of data, it's better to leave it
 running through the work pool (the default) so it gets its own transaction
 budget.
 
+### Unstable step arguments and default step options
+
+On replay, each step's arguments are validated against the journal, and a
+mismatch fails the workflow with a determinism violation. If a step's arguments
+are legitimately non-deterministic (e.g. derived from a caught stack trace) or
+can change between deploys, you can opt that step out of argument validation
+with `unstableArgs` (the step name and kind are still validated):
+
+```ts
+await step.runMutation(internal.example.recordError, { message }, {
+  unstableArgs: true,
+});
+```
+
+Sometimes a library makes the step call on your behalf, so there's no call
+site at which to pass options. For example, another component's client may
+call `ctx.runMutation` internally with its own config embedded in the
+arguments, which would fail replays of in-flight workflows when that config
+changes. For this, `step.withOptions(...)` derives a new step context that
+applies default options to every step run through it:
+
+```ts
+const pool = new Workpool(components.scrapePool, { maxParallelism: 10 });
+
+export const scrapeAll = workflow.define({
+  args: { urls: v.array(v.string()) },
+  handler: async (step, { urls }) => {
+    // Workpool embeds its config in its enqueue arguments, so changing e.g.
+    // maxParallelism would otherwise fail replays of in-flight workflows.
+    const lenient = step.withOptions({ unstableArgs: true });
+    for (const url of urls) {
+      await pool.enqueueAction(lenient, internal.scrape.page, { url });
+    }
+  },
+});
+```
+
+`withOptions` supports `unstableArgs` and a default `retry` behavior for
+actions. Per-call options always take precedence, the original `step` context
+is unaffected, and calls can be chained (later defaults win).
+
 ### Checking a workflow's status
 
 Calling a workflow returns a `WorkflowId` string, which can then be used for

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -41,7 +41,11 @@ export {
   type WorkflowId,
   type WorkflowStep,
 } from "../types.js";
-export type { RunOptions, WorkflowCtx } from "./workflowContext.js";
+export type {
+  RunOptions,
+  StepDefaults,
+  WorkflowCtx,
+} from "./workflowContext.js";
 export type { WorkflowArgs } from "./workflowMutation.js";
 export { vResultValidator } from "@convex-dev/workpool";
 

--- a/src/client/stepContext.test.ts
+++ b/src/client/stepContext.test.ts
@@ -495,6 +495,89 @@ describe("unstableArgs", () => {
   });
 });
 
+describe("withOptions", () => {
+  async function collectCalls(
+    run: (ctx: ReturnType<typeof createWorkflowCtx>) => Promise<void>,
+    count: number,
+  ): Promise<StepRequest[]> {
+    const channel = new BaseChannel<StepRequest>(0);
+    const ctx = createWorkflowCtx("wf-test" as any, channel);
+    const calls: StepRequest[] = [];
+    const drain = async () => {
+      for (let i = 0; i < count; i++) {
+        const msg = await channel.get();
+        calls.push(msg);
+        msg.resolve({ kind: "success", returnValue: null });
+      }
+    };
+    await Promise.all([run(ctx), drain()]);
+    return calls;
+  }
+
+  test("applies unstableArgs to all step kinds", async () => {
+    const calls = await collectCalls(async (ctx) => {
+      const lenient = ctx.withOptions({ unstableArgs: true });
+      await lenient.runQuery(fakeFuncRef("q"), {});
+      await lenient.runMutation(fakeFuncRef("m"), {});
+      await lenient.runAction(fakeFuncRef("a"), {});
+      await lenient.runWorkflow(fakeFuncRef("w"), {});
+    }, 4);
+    expect(calls.map((c) => c.unstableArgs)).toEqual([true, true, true, true]);
+  });
+
+  test("per-call options override defaults", async () => {
+    const calls = await collectCalls(async (ctx) => {
+      const lenient = ctx.withOptions({ unstableArgs: true });
+      await lenient.runMutation(fakeFuncRef("m"), {}, { unstableArgs: false });
+      const strict = ctx.withOptions({ unstableArgs: false });
+      await strict.runMutation(fakeFuncRef("m2"), {}, { unstableArgs: true });
+    }, 2);
+    expect(calls[0].unstableArgs).toBe(false);
+    expect(calls[1].unstableArgs).toBe(true);
+  });
+
+  test("does not affect the original ctx", async () => {
+    const calls = await collectCalls(async (ctx) => {
+      ctx.withOptions({ unstableArgs: true });
+      await ctx.runMutation(fakeFuncRef("m"), {});
+    }, 1);
+    expect(calls[0].unstableArgs).toBe(false);
+  });
+
+  test("chaining merges defaults, later wins", async () => {
+    const retry = { maxAttempts: 3, initialBackoffMs: 10, base: 2 };
+    const calls = await collectCalls(async (ctx) => {
+      const derived = ctx
+        .withOptions({ unstableArgs: true })
+        .withOptions({ retry });
+      await derived.runAction(fakeFuncRef("a"), {});
+      const overridden = derived.withOptions({ unstableArgs: false });
+      await overridden.runAction(fakeFuncRef("a2"), {});
+    }, 2);
+    expect(calls[0].unstableArgs).toBe(true);
+    expect(calls[0].retry).toEqual(retry);
+    expect(calls[1].unstableArgs).toBe(false);
+    expect(calls[1].retry).toEqual(retry);
+  });
+
+  test("retry default only applies to actions", async () => {
+    const calls = await collectCalls(async (ctx) => {
+      const withRetry = ctx.withOptions({ retry: true });
+      await withRetry.runAction(fakeFuncRef("a"), {});
+      await withRetry.runMutation(fakeFuncRef("m"), {});
+      await withRetry.runQuery(fakeFuncRef("q"), {});
+      await withRetry.runWorkflow(fakeFuncRef("w"), {});
+      // Per-call retry on an action still wins over the default.
+      await withRetry.runAction(fakeFuncRef("a2"), {}, { retry: false });
+    }, 5);
+    expect(calls[0].retry).toBe(true);
+    expect(calls[1].retry).toBeUndefined();
+    expect(calls[2].retry).toBeUndefined();
+    expect(calls[3].retry).toBeUndefined();
+    expect(calls[4].retry).toBe(false);
+  });
+});
+
 describe("transactionLimits", () => {
   const limits = { documentsRead: 5, bytesWritten: 100 };
 

--- a/src/client/workflowContext.ts
+++ b/src/client/workflowContext.ts
@@ -1,4 +1,8 @@
-import type { RetryOption, RunResult } from "@convex-dev/workpool";
+import type {
+  RetryBehavior,
+  RetryOption,
+  RunResult,
+} from "@convex-dev/workpool";
 import { BaseChannel } from "async-channel";
 import { parse } from "convex-helpers/validators";
 import type {
@@ -30,6 +34,23 @@ export type RunOptions = {
    */
   unstableArgs?: boolean;
 } & SchedulerOptions;
+
+/**
+ * Options applied to every step run through a `WorkflowCtx` derived with
+ * {@link WorkflowCtx.withOptions}. Per-call options take precedence.
+ */
+export type StepDefaults = {
+  /**
+   * If true, the journal will not validate that step arguments match on
+   * replay. See {@link RunOptions.unstableArgs}.
+   */
+  unstableArgs?: boolean;
+  /**
+   * Default retry behavior for action steps. Ignored for queries, mutations,
+   * workflows, sleeps, and events. See workpool's {@link RetryOption}.
+   */
+  retry?: RetryBehavior | boolean;
+};
 
 type InlineArgs =
   | {
@@ -134,24 +155,47 @@ export type WorkflowCtx = {
    * @param opts - Optionally name the step. Default: "sleep"
    */
   sleep(duration: number, opts?: { name?: string }): Promise<void>;
+
+  /**
+   * Derive a new `WorkflowCtx` that applies the given options to every step
+   * it runs, unless overridden at the call site. The original ctx is
+   * unaffected.
+   *
+   * This is especially useful when a library makes step calls on your behalf
+   * (e.g. another component's client calling `ctx.runMutation` internally),
+   * so you have no call site at which to pass options like `unstableArgs`:
+   *
+   * ```ts
+   * // Workpool embeds its config (e.g. maxParallelism) in its enqueue args,
+   * // so config changes would otherwise fail replays of in-flight workflows.
+   * const lenient = step.withOptions({ unstableArgs: true });
+   * await pool.enqueueAction(lenient, internal.scrape.page, { url });
+   * ```
+   *
+   * Chaining is supported; later defaults override earlier ones.
+   */
+  withOptions(defaults: StepDefaults): WorkflowCtx;
 };
 
 export function createWorkflowCtx(
   workflowId: WorkflowId,
   sender: BaseChannel<StepRequest>,
-) {
+  defaults?: StepDefaults,
+): WorkflowCtx {
   return {
     workflowId,
+    withOptions: (opts) =>
+      createWorkflowCtx(workflowId, sender, { ...defaults, ...opts }),
     runQuery: async (query, args, opts?) => {
-      return runFunction(sender, "query", query, args, opts);
+      return runFunction(sender, "query", query, args, opts, defaults);
     },
 
     runMutation: async (mutation, args, opts?) => {
-      return runFunction(sender, "mutation", mutation, args, opts);
+      return runFunction(sender, "mutation", mutation, args, opts, defaults);
     },
 
     runAction: async (action, args, opts?) => {
-      return runFunction(sender, "action", action, args, opts);
+      return runFunction(sender, "action", action, args, opts, defaults);
     },
 
     runWorkflow: async (workflow, args, opts?) => {
@@ -165,7 +209,7 @@ export function createWorkflowCtx(
         },
         retry: undefined,
         inline: false,
-        unstableArgs: unstableArgs ?? false,
+        unstableArgs: unstableArgs ?? defaults?.unstableArgs ?? false,
         schedulerOptions,
         transactionLimits: undefined,
       });
@@ -218,6 +262,7 @@ async function runFunction<
     inline?: boolean;
     transactionLimits?: TransactionLimits;
   } & RetryOption,
+  defaults?: StepDefaults,
 ): Promise<unknown> {
   const {
     name,
@@ -248,9 +293,9 @@ async function runFunction<
       function: f,
       args: args ?? {},
     },
-    retry,
+    retry: retry ?? (functionType === "action" ? defaults?.retry : undefined),
     inline: inline ?? false,
-    unstableArgs: unstableArgs ?? false,
+    unstableArgs: unstableArgs ?? defaults?.unstableArgs ?? false,
     transactionLimits,
     schedulerOptions,
   });


### PR DESCRIPTION
Allow making a version of `step` that ignores mismatched args, to pass to unstable libraries, etc.