### PR TITLE
fix(environment): disable globals by assignment so convex-test isolation survives workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.7-alpha.0
+
+- Improves patching and restoration of globals to work better with convex-test.
+  For best results, use convex-test >= 0.0.57-alpha.0
+
 ## 0.4.6
 
 - Fixes the type of `step.runWorkflow(child, args)`: it now resolves to the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@convex-dev/workflow",
-  "version": "0.4.6",
+  "version": "0.4.7-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/workflow",
-      "version": "0.4.6",
+      "version": "0.4.7-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async-channel": "^0.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "chokidar-cli": "3.0.0",
         "convex": "1.43.0",
         "convex-helpers": "0.1.114",
-        "convex-test": "0.0.52",
+        "convex-test": "0.0.57-alpha.0",
         "cpy-cli": "7.0.0",
         "eslint": "9.39.4",
         "eslint-plugin-react-hooks": "7.0.1",
@@ -2634,13 +2634,13 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.52.tgz",
-      "integrity": "sha512-C27plpAqg+5tT/whYaAoAAjSwl6bCNPZX/705nbijo1nu5L4Xnv1Ssd29KCvgM5liU5tvfo8Vz4o8Lu4wH+6fw==",
+      "version": "0.0.57-alpha.0",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.57-alpha.0.tgz",
+      "integrity": "sha512-dTR6S4HTGwcETapH0zfmaHb81PuvIScF2pRBFgpjPXOOuErSrSF5uZT7SRYrbNCDO6jBuxkZH2RNVMK9a0GQtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "convex": "^1.32.0"
+        "convex": "^1.43.0"
       }
     },
     "node_modules/copy-file": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convex-dev/workflow",
-  "version": "0.4.6",
+  "version": "0.4.7-alpha.0",
   "description": "Convex component for durably executing workflows.",
   "keywords": [
     "convex",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "chokidar-cli": "3.0.0",
     "convex": "1.43.0",
     "convex-helpers": "0.1.114",
-    "convex-test": "0.0.52",
+    "convex-test": "0.0.57-alpha.0",
     "cpy-cli": "7.0.0",
     "eslint": "9.39.4",
     "eslint-plugin-react-hooks": "7.0.1",

--- a/src/client/environment.integration.test.ts
+++ b/src/client/environment.integration.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { convexTest } from "convex-test";
+import {
+  anyApi,
+  componentsGeneric,
+  defineSchema,
+  type FunctionReference,
+} from "convex/server";
+import { v } from "convex/values";
+import { getStatus, WorkflowManager, type WorkflowComponent } from "./index.js";
+import workflowTest from "../test.js";
+
+const component = componentsGeneric().workflow as unknown as WorkflowComponent;
+const manager = new WorkflowManager(component);
+const workflowRef = anyApi.environment.workflow as FunctionReference<
+  "mutation",
+  "internal",
+  { fail: boolean },
+  boolean
+>;
+const disabledKeys = [
+  "process",
+  "Crypto",
+  "crypto",
+  "CryptoKey",
+  "SubtleCrypto",
+];
+const patchedKeys = ["Math", "Date", "console", ...disabledKeys];
+
+const functions = {
+  workflow: manager
+    .define({ args: { fail: v.boolean() }, returns: v.boolean() })
+    .handler(async (_step, { fail }) => {
+      const global = globalThis as Record<string, unknown>;
+      const disabled = disabledKeys.every((key) => global[key] === undefined);
+      if (fail) {
+        throw new Error(`handler failed with globals disabled: ${disabled}`);
+      }
+      return disabled;
+    }),
+};
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+test.each([false, true])(
+  "restores global values and descriptors after repeated workflows (throws: %s)",
+  async (fail) => {
+    // Use the real Workflow and Workpool components, including their scheduling.
+    const t = convexTest(defineSchema({}), {
+      "./_generated/api.ts": async () => ({}),
+      "./environment.ts": async () => functions,
+    });
+    workflowTest.register(t);
+    const global = globalThis as Record<string, unknown>;
+    const originals = patchedKeys.map((key) => ({
+      value: global[key],
+      descriptor: Object.getOwnPropertyDescriptor(global, key),
+    }));
+
+    for (let i = 0; i < 2; i++) {
+      const id = await t.run((ctx) =>
+        manager.start(ctx, workflowRef, { fail }),
+      );
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+      const status = await t.query((ctx) => getStatus(ctx, component, id));
+
+      if (fail) {
+        expect(status).toMatchObject({
+          type: "failed",
+          error: expect.stringContaining(
+            "handler failed with globals disabled: true",
+          ),
+        });
+      } else {
+        expect(status).toEqual({ type: "completed", result: true });
+      }
+      for (const [index, key] of patchedKeys.entries()) {
+        expect(global[key], key).toBe(originals[index].value);
+        expect(Object.getOwnPropertyDescriptor(global, key), key).toEqual(
+          originals[index].descriptor,
+        );
+      }
+    }
+  },
+);

--- a/src/client/environment.test.ts
+++ b/src/client/environment.test.ts
@@ -3,9 +3,212 @@ import {
   patchMath,
   createDeterministicDate,
   createConsole,
+  setupEnvironment,
 } from "./environment.js";
 
 describe("environment patching units", () => {
+  describe("setupEnvironment", () => {
+    const disabledKeys = [
+      "process",
+      "Crypto",
+      "crypto",
+      "CryptoKey",
+      "SubtleCrypto",
+    ] as const;
+
+    it.each(
+      disabledKeys.flatMap((key) => [
+        [key, true] as const,
+        [key, false] as const,
+      ]),
+    )(
+      "preserves the %s accessor when disabling and restoring it repeatedly (setter: %s)",
+      (key, hasSetter) => {
+        const global = globalThis as Record<string, unknown>;
+        const descriptor = Object.getOwnPropertyDescriptor(global, key);
+        const original = global[key];
+        let value = original;
+        const writes: unknown[] = [];
+        const accessor = {
+          configurable: true,
+          enumerable: descriptor?.enumerable ?? true,
+          get: () => value,
+          set: hasSetter
+            ? (next: unknown) => {
+                writes.push(next);
+                value = next;
+              }
+            : undefined,
+        };
+        Object.defineProperty(global, key, accessor);
+        const snapshots = [];
+        try {
+          for (let i = 0; i < 2; i++) {
+            const restore = setupEnvironment(
+              () => ({ now: 1234, latest: true }),
+              "accessor-test",
+            );
+            try {
+              snapshots.push({
+                value: global[key],
+                descriptor: hasSetter
+                  ? Object.getOwnPropertyDescriptor(global, key)
+                  : undefined,
+              });
+            } finally {
+              restore();
+            }
+            snapshots.push({
+              value: global[key],
+              descriptor: Object.getOwnPropertyDescriptor(global, key),
+            });
+          }
+        } finally {
+          if (descriptor) {
+            Object.defineProperty(global, key, descriptor);
+          } else {
+            delete global[key];
+          }
+        }
+
+        // Assert after restoring process/console so failures cannot break Vitest.
+        expect(snapshots).toEqual([
+          { value: undefined, descriptor: hasSetter ? accessor : undefined },
+          { value: original, descriptor: accessor },
+          { value: undefined, descriptor: hasSetter ? accessor : undefined },
+          { value: original, descriptor: accessor },
+        ]);
+        expect(writes).toEqual(
+          hasSetter ? [undefined, original, undefined, original] : [],
+        );
+      },
+    );
+
+    it.each([false, true])(
+      "restores Convex runtime descriptors after repeated setup (throws: %s)",
+      (throws) => {
+        const global = globalThis as Record<string, unknown>;
+        const keys = ["Math", "Date", "console", ...disabledKeys];
+        const hostDescriptors = Object.fromEntries(
+          keys.map((key) => [
+            key,
+            Object.getOwnPropertyDescriptor(global, key),
+          ]),
+        );
+        const hostValues = Object.fromEntries(
+          keys.map((key) => [key, global[key]]),
+        );
+        const originalCrypto = global.crypto;
+        const runtimeDescriptors = {
+          // Match udf-runtime/src/00_crypto.ts: these constructors are read-only.
+          Crypto: {
+            value: global.Crypto,
+            writable: false,
+            enumerable: false,
+            configurable: true,
+          },
+          SubtleCrypto: {
+            value: global.SubtleCrypto,
+            writable: false,
+            enumerable: false,
+            configurable: true,
+          },
+          crypto: {
+            get: () => originalCrypto,
+            set: undefined,
+            enumerable: true,
+            configurable: true,
+          },
+        };
+        const disabled: boolean[] = [];
+        const restored = [];
+        const errors = [];
+        try {
+          Object.defineProperties(global, runtimeDescriptors);
+          for (let i = 0; i < 2; i++) {
+            const restore = setupEnvironment(
+              () => ({ now: 1234, latest: true }),
+              "runtime-test",
+            );
+            try {
+              disabled.push(
+                disabledKeys.every((key) => global[key] === undefined),
+              );
+              if (throws) throw new Error("handler failed");
+            } catch (error) {
+              errors.push(error);
+            } finally {
+              restore();
+            }
+            restored.push(
+              Object.fromEntries(
+                Object.keys(runtimeDescriptors).map((key) => [
+                  key,
+                  Object.getOwnPropertyDescriptor(global, key),
+                ]),
+              ),
+            );
+          }
+        } finally {
+          // Also clean up partial setup failures so they cannot break Vitest.
+          for (const [key, descriptor] of Object.entries(hostDescriptors)) {
+            if (descriptor) {
+              Object.defineProperty(global, key, descriptor);
+              if (descriptor.set) global[key] = hostValues[key];
+            } else {
+              delete global[key];
+            }
+          }
+        }
+
+        expect(disabled).toEqual([true, true]);
+        expect(restored).toEqual([runtimeDescriptors, runtimeDescriptors]);
+        expect(errors).toEqual(
+          throws
+            ? [new Error("handler failed"), new Error("handler failed")]
+            : [],
+        );
+      },
+    );
+
+    it("restores the outer environment after a nested environment throws", () => {
+      const global = globalThis as Record<string, unknown>;
+      const keys = ["Math", "Date", "console", ...disabledKeys];
+      const snapshot = () => keys.map((key) => global[key]);
+      const original = snapshot();
+      const restoreOuter = setupEnvironment(
+        () => ({ now: 1000, latest: true }),
+        "outer",
+      );
+      const outer = snapshot();
+      let innerTime;
+      let restoredOuter;
+      let caught;
+      try {
+        const restoreInner = setupEnvironment(
+          () => ({ now: 2000, latest: false }),
+          "inner",
+        );
+        try {
+          innerTime = Date.now();
+          throw new Error("handler failed");
+        } finally {
+          restoreInner();
+        }
+      } catch (error) {
+        caught = error;
+        restoredOuter = snapshot();
+      } finally {
+        restoreOuter();
+      }
+
+      expect(caught).toEqual(new Error("handler failed"));
+      expect(innerTime).toBe(2000);
+      restoredOuter!.forEach((value, i) => expect(value).toBe(outer[i]));
+      snapshot().forEach((value, i) => expect(value).toBe(original[i]));
+    });
+  });
+
   describe("patchMath", () => {
     it("should preserve all Math methods except random", () => {
       const originalMath = Math;

--- a/src/client/environment.ts
+++ b/src/client/environment.ts
@@ -101,6 +101,7 @@ export function setupEnvironment(
   const originals = Object.fromEntries(
     patchedKeys.map((key) => [key, global[key]]),
   );
+  const readonlyProperties = new Map<string, PropertyDescriptor>();
 
   // Patch Math with seeded random based on workflowId
   global.Math = patchMath(originals.Math as typeof Math, workflowId);
@@ -123,14 +124,40 @@ export function setupEnvironment(
   // environments (e.g. convex-test) that share the same JS global scope and
   // rely on these globals internally.
 
-  // Remove non-deterministic globals
-  delete global.process;
-  delete global.Crypto;
-  delete global.crypto;
-  delete global.CryptoKey;
-  delete global.SubtleCrypto;
+  // Disable non-deterministic globals with assignments so test runtimes can
+  // intercept the writes without losing their global isolation accessors.
+  for (const key of [
+    "process",
+    "Crypto",
+    "crypto",
+    "CryptoKey",
+    "SubtleCrypto",
+  ]) {
+    const descriptor = Object.getOwnPropertyDescriptor(global, key);
+    if (
+      descriptor &&
+      ("writable" in descriptor ? !descriptor.writable : !descriptor.set)
+    ) {
+      // Convex exposes read-only Crypto/SubtleCrypto constructors and a
+      // getter-only crypto. Preserve their descriptors when replacing them.
+      readonlyProperties.set(key, descriptor);
+      Object.defineProperty(global, key, {
+        value: undefined,
+        writable: true,
+        enumerable: descriptor.enumerable,
+        configurable: descriptor.configurable,
+      });
+    } else {
+      global[key] = undefined;
+    }
+  }
 
-  return () => Object.assign(global, originals);
+  return () => {
+    Object.assign(global, originals);
+    for (const [key, descriptor] of readonlyProperties) {
+      Object.defineProperty(global, key, descriptor);
+    }
+  };
 }
 
 function noop() {}


### PR DESCRIPTION
## Summary

- `setupEnvironment` previously removed `process`, `Crypto`, `crypto`, `CryptoKey`, and `SubtleCrypto` with `delete`. convex-test 0.0.57 installs AsyncLocalStorage-backed accessors on these globals for per-call isolation; `delete` bypasses the accessor and the restore step reinstalled the values as plain data properties, so the isolation was lost for the rest of the test process.
- Globals are now disabled by assigning `undefined`, which goes through any accessor. For read-only descriptors (the Convex runtime's non-writable `Crypto`/`SubtleCrypto` and getter-only `crypto`) the property is temporarily redefined as writable and the original descriptor is restored on teardown.
- Bumps `convex-test` to `0.0.57-alpha.0` (devDependency).

Fixes #276

## Tests

- Unit tests: accessor preservation with and without setters, restoration of Convex-runtime-style read-only descriptors across repeated setups and thrown handlers, and nested environments where the inner handler throws.
- Integration test: runs real workflows through convex-test with the Workflow and Workpool components registered and asserts every patched global's value and descriptor is unchanged afterward, for both succeeding and failing handlers.
- The new tests fail 13/13 against the previous `delete`-based implementation and pass with this change. `npm test`, `npm run lint`, and `npm run typecheck` all pass.