### PR TITLE
Skip ignored workflow handler success callbacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@convex-dev/eslint-plugin": "^4.0.0",
-        "@convex-dev/workpool": "0.4.7",
+        "@convex-dev/workpool": "0.4.12",
         "@edge-runtime/vm": "5.0.0",
         "@eslint/eslintrc": "3.3.5",
         "@eslint/js": "9.39.4",
@@ -39,7 +39,7 @@
         "vitest": "5.0.0"
       },
       "peerDependencies": {
-        "@convex-dev/workpool": "^0.4.4",
+        "@convex-dev/workpool": "^0.4.12",
         "convex": "^1.36.1",
         "convex-helpers": "^0.1.99"
       }
@@ -343,6 +343,17 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@convex-dev/batch-worker": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@convex-dev/batch-worker/-/batch-worker-0.2.2.tgz",
+      "integrity": "sha512-3knigElzTVhWw1sN28EYkGBTdrJZ03vMj2PJPuFq3V0Tg41i7tcv/EWDBFQWcUaKzBWWVw693hcJtxCF3CRtEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "convex": "^1.36.1",
+        "react": "^18.3.1 || ^19.0.0"
+      }
+    },
     "node_modules/@convex-dev/eslint-plugin": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@convex-dev/eslint-plugin/-/eslint-plugin-4.0.0.tgz",
@@ -358,13 +369,16 @@
       }
     },
     "node_modules/@convex-dev/workpool": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@convex-dev/workpool/-/workpool-0.4.7.tgz",
-      "integrity": "sha512-4O3VKcJXqYZ9icDgKdVPxjDGUAFK3oG0hbUwLcyYMYgsvVKlZDhvZRmczqSBZHLyrCGPpf925byh0dBigCfAGA==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@convex-dev/workpool/-/workpool-0.4.12.tgz",
+      "integrity": "sha512-mJOtVds/vWWVdFUNhveXlQcfPFUmugZbJYjdjblgA2PpfaedtcwqYBVnLXEBI2QlspTR7HfAT3cTxJtdhVPUsg==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@convex-dev/batch-worker": "^0.2.2"
+      },
       "peerDependencies": {
-        "convex": "^1.31.7",
+        "convex": "^1.36.1",
         "convex-helpers": "^0.1.94"
       }
     },
@@ -4844,6 +4858,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.3.0.tgz",
+      "integrity": "sha512-E8LUcbtBWt20bbl2YoHfx4ZDBdxVTfOKtCZn9cDSJ4l6/nuoApcpIBcj47t2wZoVX8g2ZHuMHbiShgCR1T5Sog==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/read-package-json-fast": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "vitest": "5.0.0"
       },
       "peerDependencies": {
-        "@convex-dev/workpool": "^0.4.12",
+        "@convex-dev/workpool": "^0.4.4",
         "convex": "^1.36.1",
         "convex-helpers": "^0.1.99"
       }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     }
   },
   "peerDependencies": {
-    "@convex-dev/workpool": "^0.4.4",
+    "@convex-dev/workpool": "^0.4.12",
     "convex": "^1.36.1",
     "convex-helpers": "^0.1.99"
   },
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@convex-dev/eslint-plugin": "^4.0.0",
-    "@convex-dev/workpool": "0.4.7",
+    "@convex-dev/workpool": "0.4.12",
     "@edge-runtime/vm": "5.0.0",
     "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "9.39.4",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     }
   },
   "peerDependencies": {
-    "@convex-dev/workpool": "^0.4.12",
+    "@convex-dev/workpool": "^0.4.4",
     "convex": "^1.36.1",
     "convex-helpers": "^0.1.99"
   },

--- a/src/component/oversizedValues.ts
+++ b/src/component/oversizedValues.ts
@@ -26,7 +26,7 @@ export function checkForOversizedResult(result: RunResult): RunResult {
   if (result.kind !== "success") {
     return result;
   }
-  const sizeError = checkReturnValueSize(result.returnValue);
+  const sizeError = checkReturnValueSize(result.returnValue as Value);
   if (!sizeError) {
     return result;
   }

--- a/src/component/pool.ts
+++ b/src/component/pool.ts
@@ -186,6 +186,7 @@ export async function enqueueWorkflow(
     {
       name,
       onComplete: internal.pool.handlerOnComplete,
+      onCompleteExcludeKinds: ["success"],
       context: { workflowId, generationNumber },
     },
   );

--- a/src/component/setup.test.ts
+++ b/src/component/setup.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 import { test } from "vitest";
 import { convexTest } from "convex-test";
+import workpool from "@convex-dev/workpool/test";
 import schema from "./schema.js";
 export const modules = import.meta.glob("./**/*.*s");
 
@@ -12,7 +13,7 @@ export const componentModules = import.meta.glob(
 );
 export function initConvexTest() {
   const t = convexTest(schema, modules);
-  t.registerComponent("workpool", componentSchema, componentModules);
+  workpool.register(t, "workpool");
   return t;
 }
 

--- a/src/component/workflow.test.ts
+++ b/src/component/workflow.test.ts
@@ -6,6 +6,7 @@ import { initConvexTest } from "./setup.test.js";
 import type { Id } from "./_generated/dataModel.js";
 import { internalMutation } from "./_generated/server.js";
 import { v } from "convex/values";
+import { enqueueWorkflow, getWorkpool, handlerOnComplete } from "./pool.js";
 
 describe("workflow", () => {
   beforeEach(async () => {
@@ -13,8 +14,68 @@ describe("workflow", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
+
+  test.each(
+    ["start", "restart", "resume"].flatMap((route) =>
+      ["success", "failed"].map((kind) => ({ route, kind })),
+    ),
+  )(
+    "$route only calls handlerOnComplete for failed handlers ($kind)",
+    async ({ route, kind }) => {
+      const t = initConvexTest();
+      // Keep the real callback implementation, while observing whether workpool
+      // invokes it. A failure must still complete the workflow with an error.
+      const callback = vi.spyOn(
+        handlerOnComplete as typeof handlerOnComplete & {
+          _handler: (...args: unknown[]) => unknown;
+        },
+        "_handler",
+      );
+      const id = await t.mutation(api.workflow.create, {
+        workflowName: "callback exclusion",
+        workflowHandle: `function://;workflow.test:${kind === "success" ? "noop" : "failingHandler"}`,
+        workflowArgs: {},
+        startAsync: route === "start",
+        createOnly: route !== "start",
+      });
+      if (route === "restart") {
+        await t.mutation(api.workflow.complete, {
+          workflowId: id,
+          generationNumber: 0,
+          runResult: { kind: "failed", error: "previous attempt" },
+        });
+        await t.mutation(api.workflow.restart, {
+          workflowId: id,
+          startAsync: true,
+        });
+      } else if (route === "resume") {
+        await t.run(async (ctx) => {
+          const workflow = await ctx.db.get("workflows", id);
+          await enqueueWorkflow(
+            ctx,
+            workflow!,
+            await getWorkpool(ctx, undefined),
+          );
+        });
+      }
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+      if (kind === "success") {
+        expect(callback).not.toHaveBeenCalled();
+      } else {
+        expect(callback).toHaveBeenCalledOnce();
+        const status = await t.query(api.workflow.getStatus, {
+          workflowId: id,
+        });
+        expect(status.workflow.runResult).toMatchObject({
+          kind: "failed",
+          error: expect.stringContaining("handler failed"),
+        });
+      }
+    },
+  );
 
   test("can create a workflow async", async () => {
     const t = initConvexTest();
@@ -713,3 +774,11 @@ describe("workflow", () => {
 });
 
 export const noop = internalMutation({ args: v.any(), handler: () => {} });
+
+export const failingHandler = internalMutation({
+  args: { workflowId: v.id("workflows"), generationNumber: v.number() },
+  returns: v.null(),
+  handler: () => {
+    throw new Error("handler failed");
+  },
+});

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -87,6 +87,7 @@ export async function createHandler(
       {
         name: args.workflowName,
         onComplete: internal.pool.handlerOnComplete,
+        onCompleteExcludeKinds: ["success"],
         context: { workflowId, generationNumber: 0 },
         ...schedulerOptions,
       },
@@ -331,6 +332,7 @@ export async function restartHandler(
       {
         name: workflow.name,
         onComplete: internal.pool.handlerOnComplete,
+        onCompleteExcludeKinds: ["success"],
         context: { workflowId: args.workflowId, generationNumber },
       },
     );


### PR DESCRIPTION
Workflow handler completion already returns immediately on success. Update the workpool development dependency to 0.4.12 and set `onCompleteExcludeKinds: ["success"]` when scheduling async start, restart, and handler resume. Keep the peer dependency at `^0.4.4`: older clients ignore the option and preserve existing behavior, while 0.4.12 skips these unnecessary callbacks. Failure, cancellation, and ordinary step result handling are preserved.

Compatibility verification used the published workpool 0.4.4 JavaScript client and its component in `convex-test`. All six single/batch enqueue checks passed: the client omits the new option from serialized arguments, the component accepts the enqueue, and success/failure/cancellation callbacks still run. Only the development dependency and its lockfile resolution are upgraded.

Use workpool's test registration helper to include its nested batch worker, and accommodate the newly `unknown` success result type in the existing size check.

Validation: build and both TypeScript checks pass; 129 tests pass, including six new cases exercising callback exclusion and failure propagation for all three scheduling paths. Lint passes with three existing warnings. The change was also exercised in the isolated benchmark deployment in #284.

Stacked experiment #284 compares callback inclusion vs. exclusion on released 0.4.12, then evaluates transactional completion. Exclusion removes 600 callbacks per 100 five-step workflows (~18% fewer scheduled executions). Across three measured trials per configuration, median committed throughput changed by −20.7% at parallelism 25 and +9.6% at 100 (+6.6% including admission). Timing ranges are wide; the measured benefit is consistent callback elimination, not a universal throughput gain. See [the full results](https://github.com/get-convex/workflow/blob/ian/workpool-throughput-test/experiments/workpool/RESULTS.md).
